### PR TITLE
fix(lsp): respawn a crashed Language Server instead of staying unavailable

### DIFF
--- a/src/decode/services/lsp/client.py
+++ b/src/decode/services/lsp/client.py
@@ -67,6 +67,16 @@ class LspClient:
         # Per-URI document version: first touch is a didOpen (v1), later touches are didChange (v2+).
         self._versions: dict[str, int] = {}
 
+    @property
+    def is_alive(self) -> bool:
+        """True while the spawned subprocess is still running (its ``returncode`` is unset).
+
+        The service checks this before reusing a cached client: a server that handshook then crashed
+        mid-session is dropped and respawned once, instead of every later request failing against its
+        dead pipe for the rest of the session.
+        """
+        return self._process.returncode is None
+
     # --- handshake -----------------------------------------------------------------------------
 
     async def initialize(self) -> None:

--- a/src/decode/services/lsp/service.py
+++ b/src/decode/services/lsp/service.py
@@ -6,8 +6,10 @@ Enricher (053), and the app-exit path (054) — and it owns the lifecycle the cl
 * **Lazy, one server per project root, cached** — mirroring ``bash``'s module-level ``_EXECUTOR`` and
   ``web``'s ``_TRANSPORT`` (AGENTS.md): :data:`_CLIENTS` maps a resolved root to its :class:`LspClient`,
   spawned on first use and reused thereafter. A spawn/handshake that **fails caches the
-  :data:`_BROKEN` sentinel** so a missing or crashing server is not re-spawned on every edit/tool call
-  (no retry storm) — that root stays "unavailable" until the process restarts.
+  :data:`_BROKEN` sentinel** so a server that can't even start is not re-spawned on every edit/tool
+  call (no retry storm) — that root stays "unavailable" until the process restarts. A server that
+  handshook **then crashed mid-session** is instead dropped and respawned **once** on the next call
+  (via :attr:`LspClient.is_alive`), so it recovers rather than failing against a dead pipe all session.
 * **A patchable spawn seam** — :func:`_spawn_process` is the one place a real subprocess is created;
   unit tests patch it to inject a fake process with canned framed responses, so the suite never spawns
   real ``ty`` (mirrors ``web``'s ``_TRANSPORT`` test seam).
@@ -70,16 +72,20 @@ async def _spawn_process(root: Path) -> asyncio.subprocess.Process:
 async def _get_client(cwd: Path) -> LspClient | None:
     """Return the cached client for ``cwd``'s root, spawning lazily on first use; ``None`` if unavailable.
 
-    ``lsp_enabled == False`` short-circuits to ``None`` **without spawning**. A previously failed root
-    (cached :data:`_BROKEN`) also returns ``None`` without re-spawning (no retry storm).
+    ``lsp_enabled == False`` short-circuits to ``None`` **without spawning**. A root whose initial
+    spawn/handshake failed (cached :data:`_BROKEN`) also returns ``None`` without re-spawning (no retry
+    storm). A cached client whose subprocess has since **died** is dropped and respawned **once** — a
+    mid-session crash recovers rather than failing against a dead pipe for the rest of the session.
     """
     if not settings.lsp_enabled:
         return None
     root = Path(cwd).resolve()
     cached = _CLIENTS.get(root)
     if isinstance(cached, LspClient):
-        return cached
-    if cached is _BROKEN:
+        if cached.is_alive:
+            return cached
+        del _CLIENTS[root]  # crashed mid-session → drop and respawn below (not _BROKEN forever)
+    elif cached is _BROKEN:
         return None
     client = await _start_client(root)
     _CLIENTS[root] = client if client is not None else _BROKEN

--- a/tests/unit/decode/services/lsp/test_service.py
+++ b/tests/unit/decode/services/lsp/test_service.py
@@ -225,6 +225,32 @@ async def test_different_roots_spawn_separately(tmp_path: Path, mocker):
     assert len(lsp_service._CLIENTS) == 2
 
 
+async def test_crashed_client_is_respawned_not_stuck_unavailable(tmp_path: Path, mocker):
+    # A server that handshakes fine and serves one op, then its subprocess dies mid-session. Unlike a
+    # never-spawned root (cached _BROKEN forever), a crashed-after-handshake client must recover: the
+    # next call drops it and respawns ONCE, rather than failing against the dead pipe all session.
+    healthy, replacement = (
+        FakeLanguageServer(_canned(tmp_path)),
+        FakeLanguageServer(_canned(tmp_path)),
+    )
+    spawn = _patch_spawn(mocker, side_effect=[healthy, replacement])
+    path = _seed_root(tmp_path)
+
+    first = await lsp_service.definition(tmp_path, str(path), line=10, column=5)
+    assert isinstance(first, Location) and spawn.call_count == 1  # handshook + cached
+
+    healthy._exit()  # ty crashes: the subprocess exits (returncode set, stdout at EOF)
+
+    second = await lsp_service.definition(tmp_path, str(path), line=10, column=5)
+
+    assert isinstance(second, Location)  # recovered against the fresh server, not UNAVAILABLE
+    assert spawn.call_count == 2  # the dead client was dropped and respawned exactly once
+    cached = lsp_service._CLIENTS[tmp_path.resolve()]
+    assert (
+        isinstance(cached, LspClient) and cached._process is replacement
+    )  # the fresh client is cached
+
+
 # --- best-effort: broken spawn, dead process, timeout, malformed frame, disabled ---------------
 
 


### PR DESCRIPTION
## What

A cached `LspClient` whose `ty server` subprocess crashes **mid-session** previously failed every later code-intelligence request against its dead pipe — silently disabling the `lsp` tool **and** the post-edit diagnostics enricher for the rest of the REPL session, even though a respawn would recover it.

`_get_client` now checks `LspClient.is_alive` (`process.returncode is None`) before reusing a cached client, and drops + respawns a dead one **once**.

## Behavior

- **Can't start** (e.g. `ty` not on PATH) → still caches `_BROKEN`, no retry storm (unchanged).
- **Handshook then crashed** → dropped and respawned on the next call → recovers.

The rarer "process alive but stream desynced" case is still out of scope (best-effort → `UNAVAILABLE`).

## Tests

- New `test_crashed_client_is_respawned_not_stuck_unavailable` — serves one op, kills the fake's subprocess, asserts the next call returns a real `Location` and respawned exactly once.
- Existing `test_dead_process_is_cached_unavailable` stays green as the no-over-evict regression guard (a never-started server must NOT respawn).
- `make ci` green — **923 passed**, including the real-`ty` integration wire test (not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)