### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/decode/__init__.py
+++ b/src/decode/__init__.py
@@ -1,0 +1,3 @@
+"""decode — a terminal coding agent (agentic harness)."""
+
+__version__ = "0.1.0"

--- a/src/decode/cli.py
+++ b/src/decode/cli.py
@@ -255,6 +255,7 @@ def _runtime_config_preflight(repo: str | None = None) -> str | None:
 
 
 @click.group(invoke_without_command=True)
+@click.version_option(version=__import__("decode").__version__, prog_name="decode")
 @click.option(
     "--resume",
     is_flag=False,

--- a/tests/unit/decode/test_cli.py
+++ b/tests/unit/decode/test_cli.py
@@ -1042,3 +1042,23 @@ def test_cli_no_repo_passes_none_to_run_app(mocker):
     run_app.assert_awaited_once()
     assert run_app.await_args.kwargs.get("repo") is None
     assert run_app.await_args.kwargs.get("local") is False
+
+
+# --version flag
+
+
+def test_cli_version_option_exists():
+    """`--version` is registered on the CLI group and exits cleanly."""
+    result = CliRunner().invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "decode" in result.output
+    assert "0.1.0" in result.output
+
+
+def test_version_option_does_not_trigger_startups():
+    """--version exits before any startup guards or env checks — pure metadata."""
+    # Even with no provider configured, --version must succeed (no real provider key needed).
+    result = CliRunner().invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "GEMINI_API_KEY" not in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
This PR adds a `--version` flag to the `decode` CLI.

**Changes:**
- Added `__version__ = "0.1.0"` to `src/decode/__init__.py`.
- Added `@click.version_option` decorator to the CLI group in `src/decode/cli.py`.
- Added unit tests in `tests/unit/decode/test_cli.py` to verify the flag behavior.

**Test Evidence:**
```
tests/unit/decode/test_cli.py::test_cli_version_option_exists PASSED
tests/unit/decode/test_cli.py::test_version_option_does_not_trigger_startups PASSED
============================== 2 passed in 0.96s ==============================
```

Built end-to-end inside a decode sandbox Workspace and shipped by Hand-back.