### PR TITLE
fix: kitaru stack activation order, infra docs, and the demo-6 KG skill

### DIFF
--- a/.decode/skills/demo-6-article-kg/SKILL.md
+++ b/.decode/skills/demo-6-article-kg/SKILL.md
@@ -12,7 +12,8 @@ Work the steps in order. Do not skip ahead to the HTML.
 ## Step 0 — paths and plan
 
 Both artifacts go in the output directory named in the **Output default** line at the very end of
-these instructions — unless the human named a destination, which wins. Call it `<OUT>`:
+these instructions — normally `.decode/outputs/`, but a destination the human named always wins.
+Resolve it once, call it `<OUT>`, and use `<OUT>` everywhere below:
 
 - `<OUT>/graph.json` — the extraction
 - `<OUT>/kg.html` — the page
@@ -91,7 +92,8 @@ The loop only updates coordinates and classes — it never creates or destroys e
 groups edges → edge labels → nodes so nodes sit on top. Radius is `6 + min(9, degree * 1.4)`; fill
 is the node's type color.
 
-**Simulation.** One `tick()` applying three forces, then integrating:
+**Simulation.** A hand-rolled force simulation in vanilla JS — no library, no framework. One
+`tick()` applying three forces, then integrating:
 
 - *Repulsion*, every node pair: magnitude `5000 / distanceSquared`, pushing apart along the line
   between them. Clamp `distanceSquared` to a minimum of 1 and jitter coincident nodes.

--- a/.decode/skills/demo-6-article-kg/SKILL.md
+++ b/.decode/skills/demo-6-article-kg/SKILL.md
@@ -3,42 +3,45 @@ name: demo-6-article-kg
 description: Demo skill that web-fetches three Decoding AI knowledge-graph articles, has the agent itself distill them into a typed entity/relation graph, and renders an interactive dark-themed force-directed KG into one self-contained kg.html — no graph library, no CDN.
 ---
 
-The hardcore one: turn three live articles into a knowledge graph you can play with in the
-browser. Fetch the articles, distill them into typed entities and labeled relations — **you are
-the extractor**, no NLP library — and render an interactive force-directed graph into one
-self-contained HTML page.
+The hardcore one: turn three live articles into a knowledge graph you can play with in the browser.
+You do all of it — you are the extractor (no NLP library) and you are the renderer (no graph
+library, no CDN, no framework). Two artifacts, one page that works the instant it lands.
 
-Two artifacts, both under `.decode/outputs/` (unless the human named a different path):
-`graph.json` (the extraction checkpoint) and `kg.html` (the visualization).
+Work the steps in order. Do not skip ahead to the HTML.
 
-## Plan first
+## Step 0 — paths and plan
 
-Lay out the pipeline with `todo_write` (fetch → clean → extract → render → verify) and tick
-items off as you go.
+Both artifacts go in the output directory named in the **Output default** line at the very end of
+these instructions — unless the human named a destination, which wins. Call it `<OUT>`:
 
-## 1. Fetch and clean the sources
+- `<OUT>/graph.json` — the extraction
+- `<OUT>/kg.html` — the page
 
-`web_fetch` each article (the tool returns Markdown):
+Put the pipeline in `todo_write` as five items (fetch, extract, render, verify, report) and write
+the real `<OUT>` path into the first one so you never re-derive it.
+
+## Step 1 — fetch the three sources
+
+One `web_fetch` per URL (the tool returns Markdown):
 
 - https://www.decodingai.com/p/keep-knowledge-graph-clean
 - https://www.decodingai.com/p/understanding-neo4j-graph-agent-memory-system
 - https://www.decodingai.com/p/ship-a-knowledge-graph-ontology-in-5-minutes
 
-Clean each one before extracting: keep the title and the body prose; drop navigation, subscribe
-buttons and CTAs, comment sections, footers, and trailing "read more" link lists. If a fetch
-fails or comes back truncated, say so plainly and work with what you have — never invent content
-you did not fetch.
+Keep the title and body prose. Ignore navigation, subscribe buttons, CTAs, comments, footers and
+trailing "read more" lists. If a fetch fails or comes back truncated, say so plainly and work with
+what you have — never invent content you did not fetch.
 
-## 2. Extract the graph — you are the extractor
+## Step 2 — extract one merged graph
 
-Read the cleaned articles and distill ONE merged graph across all three (an entity shared by two
-articles appears once). Write it to `.decode/outputs/graph.json`:
+Distill ONE graph across all three articles: an entity discussed in two articles is ONE node, not
+two. Write it to `<OUT>/graph.json`:
 
 ```json
 {
   "nodes": [
-    {"id": "Ontology", "type": "concept", "desc": "one-sentence synthesis in your own words"},
-    {"id": "Neo4j", "type": "tool", "desc": "..."}
+    {"id": "Ontology", "type": "concept", "desc": "one sentence in your own words"},
+    {"id": "Neo4j", "type": "tool", "desc": "one sentence in your own words"}
   ],
   "edges": [
     {"source": "Ontology", "target": "KG drift", "label": "prevents"}
@@ -46,48 +49,94 @@ articles appears once). Write it to `.decode/outputs/graph.json`:
 }
 ```
 
-- `type` is one of `concept` / `tool` / `pattern` / `problem` — pick the best fit.
-- Edges are **directed** and labeled with a short verb phrase (`prevents`, `stores`, `queries`).
-- **20–35 nodes total**: the key ideas, not every noun. No orphan nodes — everything connects;
-  every edge endpoint must be an existing node `id`.
-- `desc` is one sentence of YOUR synthesis, not a quote.
+- **20–35 nodes.** The key ideas, not every noun.
+- `type` is exactly one of `concept` / `tool` / `pattern` / `problem`.
+- `desc` is one sentence of your own synthesis, not a quote.
+- Edges are directed; `label` is a short verb phrase (`prevents`, `stores`, `queries`).
+- Every `source` and `target` matches a node `id` exactly — ids are case-sensitive.
+- No orphans: every node has at least one edge.
 
-## 3. Render — one self-contained interactive page
+Before moving on, re-read what you wrote and confirm the node count is in range, every edge endpoint
+exists, and no node is orphaned. Fixing it here is cheap; fixing it after the page is written is not.
 
-Author `.decode/outputs/kg.html` by hand — **one file, zero external requests, no graph
-library** (nothing loaded from a CDN: no external scripts, stylesheets, or fonts). Inline
-everything:
+## Step 3 — write the page
 
-- The graph data inlined as `const GRAPH = { ... };` — paste the **literal JSON** from
-  `graph.json` right there as the value (open brace, real `"nodes"` and `"edges"` arrays, close
-  brace). Do **NOT** leave a placeholder or template token — no `{{GRAPH}}`, no `<DATA>`, no
-  "insert graph here", nothing meant to be substituted in a later pass. There is no second pass:
-  the single write must already contain every node and edge, and the file must be openable and
-  fully working the instant it lands. If you built the page from a template string, expand it
-  before writing — never write the unexpanded template.
-- A hand-rolled **force simulation in vanilla JS** (~80 lines) drawing into an inline `<svg>`:
-  pairwise repulsion, springs along edges, gentle centering; let it keep settling live after an
-  initial burst of ticks.
-- **Drag**: pointer-grab any node and the layout re-settles around it.
-- **Hover**: highlight the node, its edges, and its neighbors; dim the rest; fill a side detail
-  card with the node's `desc` and its relations rendered as `prevents → KG drift` lines.
-- Node color by `type` (legend in the header), node radius by degree, edge labels as small
-  `<text>` along each line.
-- **Design — dark minimal, modern without a framework**: full-viewport canvas; sticky header
-  with a title, the three source articles as links, and the type legend; the hover detail card
-  as a fixed side panel; CSS variables, system font stack, subtle glow on nodes.
+**One `write` call produces a finished file.** There is no second pass. The data goes in as a
+literal — the actual `{ "nodes": [...], "edges": [...] }` you just wrote to `graph.json`, copied in
+full. Never emit `{{GRAPH}}`, `<DATA>`, `/* graph here */`, `...`, or any token you intend to
+substitute later, and never write an unexpanded template string. If you catch yourself planning to
+"fill in the data next", stop and write the whole file instead.
 
-## 4. Verify and report
+Author `<OUT>/kg.html` in this order — each section complete before the next:
 
-1. Validate the checkpoint:
-   `uv run python -m json.tool .decode/outputs/graph.json > /dev/null` succeeds, and a one-liner
-   confirms every edge endpoint is a node id and the node count sits in 20–35.
-2. The page carries real data, not a template: `grep -c "const GRAPH" .decode/outputs/kg.html`
-   prints 1, and `grep -Ec '\{\{|\}\}|insert .*here|<DATA>' .decode/outputs/kg.html` prints 0 —
-   any leftover substitution token means the data was never inlined; fix it before reporting.
-3. The page is self-contained: `grep -c 'src="http' .decode/outputs/kg.html` prints 0. Confirm
-   the inlined node/edge counts match `graph.json` (e.g. count `"id":` occurrences in each).
-4. Tell the human to open it: `open .decode/outputs/kg.html`.
+1. `<head>`: `<title>`, and one `<style>` block. No external stylesheet, script, or font.
+2. `<header>`: the page title, the three article URLs as links, and the type legend (a colored dot
+   plus the type name, four of them).
+3. An empty `<svg>` filling the viewport, and an empty detail card `<div>` positioned on the right.
+4. One `<script>` block, in this order: the data, the model, the drawing, the simulation, the
+   interactions, the start.
 
-Report the node count by type, the edge count, the three most-connected entities, one relation
-across articles that surprised you, and the one-line command to open the page.
+### What goes in the script, in order
+
+**Data.** `const GRAPH = ` followed by the literal object. This is the first statement in the block.
+
+**Model.** Map each node to an object carrying `x`, `y`, `vx`, `vy` and `degree`. Seed positions on
+a circle around the viewport center — never all at one point, or the repulsion divides by zero.
+Resolve every edge's `source`/`target` string to its node object once, up front, so the loop never
+searches by id. Count degree while you do it. Build a neighbor set per node id for the hover step.
+
+**Drawing.** Create the SVG elements once, before the loop starts: a `<line>` and a small `<text>`
+per edge, and a `<g>` per node holding a `<circle>` and a `<text>` label. Keep references to them.
+The loop only updates coordinates and classes — it never creates or destroys elements. Order the
+groups edges → edge labels → nodes so nodes sit on top. Radius is `6 + min(9, degree * 1.4)`; fill
+is the node's type color.
+
+**Simulation.** One `tick()` applying three forces, then integrating:
+
+- *Repulsion*, every node pair: magnitude `5000 / distanceSquared`, pushing apart along the line
+  between them. Clamp `distanceSquared` to a minimum of 1 and jitter coincident nodes.
+- *Springs*, along each edge: pull proportional to `(distance - 110) * 0.01`.
+- *Centering*: nudge each node toward the viewport center by `0.0015` of its offset.
+- Integrate: multiply velocity by `0.86` damping, add to position, clamp inside the viewport with a
+  margin so nothing hides under the header.
+
+Scale all forces by an `alpha` that starts at 1 and decays ~0.5% per tick toward a floor of about
+0.06 — that floor is what keeps the layout gently alive instead of frozen. Run ~250 ticks before the
+first paint so the page opens settled, then `requestAnimationFrame` a loop of tick + draw.
+
+**Interactions.**
+
+- *Drag*: `pointerdown` on a node pins it and captures the pointer; `pointermove` sets its position
+  and zeroes its velocity; `pointerup` unpins and releases. Bump `alpha` on grab so the graph
+  re-settles around it.
+- *Hover*: highlight the node and its edges, dim every non-neighbor, and fill the detail card with
+  the node's type, id, `desc`, and its relations — outgoing as `label → target`, incoming as
+  `source label →`. Clear it on leave, but not mid-drag.
+
+**Design.** Dark, minimal, no framework: CSS variables for the palette and the four type colors, a
+system font stack, full-viewport canvas, sticky translucent header, the detail card as a fixed
+rounded panel, a subtle glow on the hovered node, and dimming via opacity.
+
+## Step 4 — verify
+
+One `bash` call. All four must hold:
+
+```bash
+python3 -m json.tool <OUT>/graph.json > /dev/null && echo "json ok"
+grep -c 'src="http' <OUT>/kg.html                        # 0 — nothing loaded from the network
+grep -Ec '\{\{|<DATA>|graph here|\.\.\.' <OUT>/kg.html   # 0 — no leftover placeholder
+grep -c 'const GRAPH' <OUT>/kg.html                      # 1 — the data is inlined
+```
+
+Then confirm the page carries the whole graph: count `"id":` occurrences in `kg.html` and in
+`graph.json` and check they match. Any mismatch means the data was truncated — rewrite the file in
+full, do not patch it.
+
+## Step 5 — report
+
+Node count by type, edge count, the three most-connected entities, one cross-article relation that
+surprised you, and the command to open it:
+
+```bash
+open <OUT>/kg.html
+```

--- a/getting_started/infra.md
+++ b/getting_started/infra.md
@@ -15,6 +15,49 @@ decode already runs its *sandboxes* on Modal (`SANDBOX_MODE=modal`). This stack 
 agent itself** there. [`scripts/deploy.sh`](../scripts/deploy.sh) provisions all of it; **§1 is the only
 part you type by hand.**
 
+## Quickstart
+
+**Do [§1](#1-what-you-must-do-by-hand) first** — the toolchain, `gcloud auth login`, `modal token set`,
+the Docker containerd toggle, and `.env`. `deploy.sh` refuses to start without them. Then:
+
+**1. Deploy** (~10-15 min; it stops once to ask you to approve the 80/443 firewall rule):
+
+```bash
+scripts/deploy.sh up
+```
+
+**2. Read the URL** — it is derived from the server's IP, so it changes every rebuild:
+
+```bash
+scripts/deploy.sh status         # the `server` row, e.g. https://34.153.164.72.nip.io
+```
+
+That one URL is both the API the CLI talks to and the dashboard you open in a browser.
+
+**3. Get the dashboard password** — user is `admin`, password was generated during `up`:
+
+```bash
+pbcopy < ~/.config/decode/kitaru-admin-password    # copies it; do NOT echo or `cat` it
+```
+
+**4. Run something:**
+
+```bash
+make run-remote TASK="run bash 'uname -a && pwd' and tell me what you see"
+```
+
+Want a **Linux x86-64** kernel and `/workspace` — that proves the `bash` ran in the Modal sandbox and
+not on your laptop. The first submit builds and pushes the flow image (3-5 min); later ones reuse it
+(~90s). Watch it land with `uv run kitaru executions list`.
+
+**Done for the day?** The stack bills ~$16/month while it is up:
+
+```bash
+scripts/deploy.sh down <your-project>
+```
+
+Everything below is the detail behind these four steps.
+
 ## The shape (and why each piece exists)
 
 | Piece | What | Why this and not more |
@@ -153,7 +196,8 @@ Every step checks before it creates, so a re-run after a failure resumes instead
 7. **Login** — mints the `decode-runner` service account + API key over the REST API, then
    `kitaru login`.
 8. **Stack** — registers the GCP connector, GCS artifact store, AR registry, Modal orchestrator and
-   sandbox, assembles the `prod-modal` stack, activates it, and runs `kitaru init`.
+   sandbox, assembles the `prod-modal` stack, runs `kitaru init`, then activates it (that order
+   matters — §4).
 9. **Secrets** — writes the `decode-modal` secret (Modal tokens) and mirrors `.env` into the
    `decode-prod` Environment Bucket.
 
@@ -299,6 +343,33 @@ Your local `kitaru` client still points at the dead server; the next `up` logs i
 
 ## 3. Run a headless agent
 
+### How the CLI reaches the server
+
+No URL is passed on the command line — `decode run` reads it from the client config `kitaru login`
+wrote back in `up` step 7. Two files, neither under `~/.config/kitaru` (that path does not exist —
+looking there is a dead end):
+
+| Path | What |
+|---|---|
+| `~/Library/Application Support/kitaru/config.yaml` | `store.type: rest` + `store.url: https://<ip>.nip.io` — the switch from a local SQLite store to your server, plus `active_stack_id` / `active_project_id` |
+| `~/Library/Application Support/kitaru/credentials.yaml` | the API token, sent as a bearer on every REST call. **Secret — never `cat` it into a terminal an agent can read** |
+| `.kitaru/config.yaml` (repo-local) | `active_stack_id` / `active_project_id` for this checkout; also the source-root marker (§4) |
+
+The chain that put them there: `kitaru_bootstrap_api_key.py` password-grants a JWT with the admin
+password → creates the `decode-runner` service account → writes its key to
+`~/.config/decode/kitaru-api-key` → `kitaru login <url> --api-key …` exchanges it for the stored token.
+
+So a submit is: client REST-calls the server for the `prod-modal` stack definition → builds the flow
+image locally and pushes it to Artifact Registry → uploads the code archive to GCS → Modal pulls and
+runs it → checkpoints flow back over that same REST connection. **The Modal container reaches the
+server at the same public `nip.io` URL your laptop does** — which is why §1.5's firewall rule cannot be
+narrowed to your IP.
+
+Connection broken? `uv run kitaru stack list` is the cheapest probe — it either answers off the server
+or tells you the auth is dead. Re-run `scripts/deploy.sh update`, which re-mints and re-logs in.
+
+### Submit
+
 ```bash
 make run-remote TASK="explain what this repo does"
 make run-remote TASK="fix the failing test" REPO=https://github.com/you/your-repo.git
@@ -312,10 +383,23 @@ DOCKER_BUILDKIT=1 KITARU_STACK=prod-modal DECODE_ENV=prod SANDBOX_MODE=modal \
   uv run --group remote decode run "$TASK" --repo "$REPO"
 ```
 
-`KITARU_STACK` is the zero-code seam: decode's flows call `.run()` with no stack argument, so the
-ambient stack decides where they execute. A submit builds and pushes the flow image (3-5 min) only when
-the code, the deps or the Docker settings changed; otherwise it reuses the recorded build (`Reusing
-existing build …`, ~90s). `SANDBOX_MODE` picks where the agent's `bash` lands:
+`KITARU_STACK` is the zero-code seam: decode's flows call `.run()` with no stack argument, so an
+ambient value decides where they execute. Resolution order:
+
+```
+explicit  .run(stack=…)   >   KITARU_STACK env   >   the configured active stack
+```
+
+**`KITARU_STACK` and "the active stack" are different knobs, not two names for one.** Kitaru is
+explicit about it (`kitaru/_config/_active_context.py`): *"`KITARU_STACK` is an execution default and
+does not set ZenML's active stack."* So `make run-remote` lands on `prod-modal` because the Makefile
+exports it — regardless of what `kitaru stack current` reports. The active stack is what bare
+`uv run kitaru …` commands and the `stack` row of `deploy.sh status` read. Expect to see them disagree;
+only the `status` row is worth fixing (`uv run kitaru stack use prod-modal`).
+
+A submit builds and pushes the flow image (3-5 min) only when the code, the deps or the Docker settings
+changed; otherwise it reuses the recorded build (`Reusing existing build …`, ~90s). `SANDBOX_MODE` picks
+where the agent's `bash` lands:
 
 | `SANDBOX_MODE` | Where `bash` runs | `--repo` Workspace | Hand-back |
 |---|---|---|---|
@@ -397,9 +481,15 @@ password and every secret in the clear. The DENY rule at priority 100 beats it.
 azureml. Modal ships as a ZenML *integration*, so the stack is assembled with the `zenml` CLI — Kitaru
 reads the same stacks off the same server.
 
-**`kitaru init` is mandatory.** Without the `.kitaru` marker, ZenML infers the source root from the
-entrypoint script — for `uv run decode` that is `.venv/bin` — and the code archive uploads **empty**:
-`RuntimeError: The code archive to be uploaded does not contain any files.`
+**`kitaru init` is mandatory — and must run BEFORE `kitaru stack use`.** Without the `.kitaru` marker,
+ZenML infers the source root from the entrypoint script — for `uv run decode` that is `.venv/bin` — and
+the code archive uploads **empty**: `RuntimeError: The code archive to be uploaded does not contain any
+files.` But `init` also *writes* `.kitaru/config.yaml` with its own `active_stack_id: <default>`, so
+running it after `stack use` silently reverts the selection. That bug only bites a **fresh** deploy —
+later `up`s skip `init` because `.kitaru` already exists, so it hides on every re-run — and it is
+cosmetic for runs (`make run-remote` exports `KITARU_STACK`, §3), but it leaves `deploy.sh status`
+reporting `stack default` and the verify check below failing for no real reason. `ensure_stack` now
+orders them `init` → `use`.
 
 **The `remote` dependency group is all-or-nothing.** Submitting needs ZenML's *entire* `gcp`
 integration locally (`gcsfs`, `kfp`, `google-cloud-aiplatform`, `kubernetes`, …). Miss one package and

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -384,10 +384,14 @@ ensure_stack() {
       -o modal-orch -a gcs-kitaru -c ar-kitaru -sb modal-sandbox >/dev/null
   fi
 
-  uv run kitaru stack use "${STACK}" >/dev/null
-  # Pins the source root. Without it ZenML infers it from the entrypoint script — for `uv run
+  # `init` BEFORE `use`, and the order is load-bearing. `kitaru init` writes .kitaru/config.yaml with
+  # its own `active_stack_id: <default>`, so running it after `stack use` silently reverts the
+  # selection — on a FRESH deploy only (later `up`s skip init, so the bug hides on every re-run).
+  #
+  # Pins the source root too. Without it ZenML infers it from the entrypoint script — for `uv run
   # decode` that is .venv/bin, and the code archive uploads empty.
   [ -d "${REPO_ROOT}/.kitaru" ] || uv run kitaru init >/dev/null
+  uv run kitaru stack use "${STACK}" >/dev/null
   log "stack ${STACK} active"
 }
 


### PR DESCRIPTION
## What

Three things found while bringing the Kitaru stack up on GCP for the first time.

### 1. `deploy.sh` activated the wrong stack on a fresh deploy

`kitaru init` writes `.kitaru/config.yaml` with its own `active_stack_id` pointing at the default stack, so running it *after* `kitaru stack use` silently reverted the selection. Reproduced and confirmed by watching the ids move:

```
after `kitaru init`      -> active_stack_id: d91a4f51…  (default)
after `kitaru stack use` -> active_stack_id: 78f38550…  (prod-modal)
```

It only bit a **fresh** deploy — later `up`s skip `init` because `.kitaru` already exists — which is why it hid on every re-run and why `deploy.sh status` reported `stack default` right after a successful provision. Cosmetic for runs (`make run-remote` exports `KITARU_STACK`, a separate knob), but it made the documented verify check fail for no real reason.

### 2. `getting_started/infra.md`

- **Quickstart**: deploy, read the URL, get the password, run a command.
- **How the CLI reaches the server** — previously undocumented. The client config paths (`~/Library/Application Support/kitaru/`, *not* `~/.config/kitaru`, which does not exist), the `kitaru login` bootstrap chain, and what crosses the wire on submit.
- **`KITARU_STACK` vs ZenML's active stack are different knobs.** The old text called `KITARU_STACK` "the ambient stack", conflating them. Kitaru is explicit: *"`KITARU_STACK` is an execution default and does not set ZenML's active stack."* Added the resolution order.
- What `kitaru init` writes, beyond the source-root marker.

### 3. `demo-6-article-kg` render step

The skill reliably produced a correct `graph.json` but a `kg.html` that needed follow-up turns. The previous fix added prose forbidding placeholders; it did not help. Restructured rather than lengthened:

- the file skeleton in **build order**, and the script block's internal order
- **concrete constants** instead of adjectives — repulsion `5000/d²`, spring `(d-110)*0.01`, centering `0.0015`, damping `0.86`, alpha floor `0.06`, ~250 warm-up ticks, radius `6+min(9, degree*1.4)`
- the three silent failure modes as instructions: seed positions on a circle, resolve edge endpoints once up front, create SVG elements before the loop
- forbid the two-pass **plan**, not just the placeholder token it produces
- a graph self-check at the end of the extract step, where fixing is cheap

The agent still writes every line of the page — no bundled renderer, no graph library, no CDN.

## Testing

`2122 passed` locally before pushing, and again in the pre-push hook.

The first push attempt **failed** on two demo-skill contract tests: the rewrite had dropped `"vanilla"` and replaced all nine `.decode/outputs/` mentions with an `<OUT>` placeholder. Third commit repairs both — the outputs path is now named once in step 0 with `<OUT>` used thereafter, so the contract holds and a human-named destination still wins.

## Not covered

The skill rewrite is **untested against a live model**. It addresses the most likely cause (generation length on one large write) but that has not been confirmed by an actual run.

Separately found, not in this PR: `COMPACTION_CONTEXT_WINDOW_TOKENS` defaults to 1,048,576 (a Gemini window) while the Modal-served Qwen3.6-35B-A3B reports `max_model_len: 262144`. Both compaction tiers therefore fire *above* the endpoint's hard ceiling and effectively never run. Does not affect demo-6 (three articles ≈ 18k tokens, 7% of the window) but will affect any long session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)