### PR TITLE
refactor: rename AgentTurnHandler._run_leg to _run_turn

### DIFF
--- a/src/decode/agent/loop.py
+++ b/src/decode/agent/loop.py
@@ -162,7 +162,7 @@ class AgentTurnHandler:
                     if pending_results is not None:
                         # Deferred resume leg: no new prompt, so steering rides the history instead.
                         self._append_steering(steering)
-                        output = await self._run_leg(ctx, deferred_results=pending_results)
+                        output = await self._run_turn(ctx, deferred_results=pending_results)
                         pending_results = None
                     else:
                         prompt = self._compose_prompt(next_prompt, steering)
@@ -177,7 +177,7 @@ class AgentTurnHandler:
                             next_prompt = "\n".join(follow_ups)
                             continue
                         self._heal_dangling_tool_calls()
-                        output = await self._run_leg(ctx, prompt=prompt)
+                        output = await self._run_turn(ctx, prompt=prompt)
 
                     if isinstance(output, DeferredToolRequests):
                         # A gated tool paused the run: resolve approvals and loop back to resume.
@@ -389,7 +389,7 @@ class AgentTurnHandler:
         )
         return elided
 
-    async def _run_leg(
+    async def _run_turn(
         self,
         ctx: TurnContext,
         *,

--- a/tests/unit/decode/agent/test_loop.py
+++ b/tests/unit/decode/agent/test_loop.py
@@ -1007,7 +1007,7 @@ def _log_line_types(log: SessionLog) -> list[str]:
     return types
 
 
-async def test_run_leg_captures_input_tokens_and_property_exposes_it(agent):
+async def test_run_turn_captures_input_tokens_and_property_exposes_it(agent):
     emitted: list[events.Event] = []
     handler = AgentTurnHandler(agent, deps=_deps(emitted.append))
 
@@ -1088,7 +1088,7 @@ async def test_leg_gauge_reads_last_response_not_cumulative_usage(agent, mocker)
     ]
     handler = _drive_stub_leg(agent, mocker, messages, cumulative_input=670)
 
-    await handler._run_leg(_ctx(0, "go", []), prompt="go")
+    await handler._run_turn(_ctx(0, "go", []), prompt="go")
 
     # The last response's own request usage — NOT 100+220+350 = 670 (the cumulative RunUsage).
     assert handler.last_input_tokens == 350
@@ -1150,7 +1150,7 @@ async def test_all_unpopulated_usage_leg_gauges_zero_and_never_compacts(agent, m
     run = _StubRun(messages, cumulative_input=100)  # cumulative is non-zero; per-response is 0
     mocker.patch.object(handler._agent, "iter", return_value=_StubIterCM(run))
 
-    await handler._run_leg(_ctx(0, "go", emitted), prompt="go")
+    await handler._run_turn(_ctx(0, "go", emitted), prompt="go")
     assert handler.last_input_tokens == 0
     await handler._maybe_auto_compact()
 
@@ -1494,7 +1494,7 @@ async def test_next_leg_overwrites_the_post_compaction_estimate(agent, mocker):
     seeded = handler.last_input_tokens
     assert seeded == compaction.estimate_history_tokens(handler.message_history)
 
-    # The next leg reports its own per-request usage; _run_leg overwrites the estimate with it.
+    # The next leg reports its own per-request usage; _run_turn overwrites the estimate with it.
     messages: list[ModelMessage] = [
         _user_msg("go"),
         ModelResponse(parts=[TextPart(content="a")], usage=RequestUsage(input_tokens=4242)),
@@ -1502,7 +1502,7 @@ async def test_next_leg_overwrites_the_post_compaction_estimate(agent, mocker):
     run = _StubRun(messages, cumulative_input=4242)
     mocker.patch.object(handler._agent, "iter", return_value=_StubIterCM(run))
 
-    await handler._run_leg(_ctx(0, "go", emitted), prompt="go")
+    await handler._run_turn(_ctx(0, "go", emitted), prompt="go")
 
     assert handler.last_input_tokens == 4242
     assert handler.last_input_tokens != seeded


### PR DESCRIPTION
## Summary

Renames the private method `AgentTurnHandler._run_leg` to `_run_turn` so the method name matches the class it lives on. Pure rename — no behavior change.

## Changes

- `src/decode/agent/loop.py` — definition (`:392`) and both call sites (`:165`, `:180`)
- `tests/unit/decode/agent/test_loop.py` — 3 call sites, 1 stale comment, and the test function name `test_run_leg_captures_...` → `test_run_turn_captures_...`

`Runner._run_turn` in `src/decode/harness/runner.py:131` is a different class and was left untouched — no collision.

## Test plan

- `uv run pytest tests/unit/decode/agent/test_loop.py -q` → 54 passed
- pre-commit format + lint passed on commit and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)