### PR TITLE
docs: frame Qwen3.6-35B-A3B as the course default in the Modal catalog

### DIFF
--- a/running_the_code/modal_models.md
+++ b/running_the_code/modal_models.md
@@ -6,13 +6,17 @@
 
 ## TL;DR
 
-For a ReAct coding-agent harness (LLM ⇄ tools loop, OpenAI-compatible serving):
+For a ReAct coding-agent harness (LLM ⇄ tools loop, OpenAI-compatible serving), working through this
+course:
 
 | Pick | Model ID | Agentic GPU | Why |
 |---|---|---|---|
-| **Best fit** | `openai/gpt-oss-120b` | **1×B200** | Native OpenAI tool-call format → cleanest harness integration; single GPU; highest interactivity |
-| **Dev default** | `Qwen/Qwen3.6-35B-A3B-FP8` | **1×H100** | Cheapest serve (MoE ~3B active); strong Qwen tool-calling; iterate without burning credits |
-| **Max capability** | `zai-org/GLM-5.2-FP8` | **8×B200** | Flagship agentic-coding tuning; expensive — reserve for hard tasks (`zai-org/GLM-4.7` is the cheaper fallback) |
+| **Best fit — course default** | `Qwen/Qwen3.6-35B-A3B-FP8` | **1×H100** | Cheapest serve by a wide margin (MoE, ~3B active); strong Qwen tool-calling through the `hermes`/`qwen` parser. You will re-run the loop hundreds of times while building — this is the one that lets you do that without rationing credits |
+| **Middle ground** | `openai/gpt-oss-120b` | **1×B200** | Native OpenAI tool-call format → least harness friction; ~2–3× the interactivity. Step up here when slow turnaround starts costing you more than GPU time |
+| **Max capability** | `zai-org/GLM-5.2-FP8` | **8×B200** | Flagship agentic-coding tuning — the ceiling of what the harness can do. 8× the GPU at the priciest tier; reserve for hard tasks (`zai-org/GLM-4.7` is the cheaper fallback) |
+
+The three are a **cost/capability ladder, not a ranking** — every step of this course is built and
+tested against the Qwen default. Reach up the ladder when a specific task actually demands it.
 
 **The rest of the catalog** (23 models: 12 Qwen, 4 Gemma, GPT-OSS, Nemotron, 2 DeepSeek, 2 GLM,
 Kimi) is browsable in the dashboard. Skip the small models (Qwen ≤9B, Gemma E2B/E4B — can't hold
@@ -21,15 +25,23 @@ tool discipline) and the frontier giants (`Qwen3.5-397B-A17B-FP8`, `DeepSeek-V4-
 
 ## Selection criteria for a coding-agent harness
 
-Ranked by how much each matters to `decode`'s loop:
+Ranked by how much each matters to `decode`'s loop **while you are learning it**:
 
-1. **Tool / function-calling reliability — #1.** Native OpenAI format wins.
-2. **Long context (≥128k)** — whole files, session replays, compaction; the agentic benchmark below
+1. **Tool / function-calling reliability — #1.** A model that mis-formats tool calls makes the loop
+   unteachable: you end up debugging the model instead of your harness. Native OpenAI format
+   (GPT-OSS) is the smoothest, but Qwen's `hermes`/`qwen` parser clears this bar too — and clearing
+   the bar is what counts here, not winning it.
+2. **Cost per learning iteration.** Course-specific, and the reason the default is what it is: you
+   will run the loop hundreds of times, most of them on turns you already understand. A model
+   ~an order of magnitude cheaper to serve buys proportionally more attempts from a fixed credit
+   budget. On a production harness this criterion would rank last; here it ranks second.
+3. **Long context (≥128k)** — whole files, session replays, compaction; the agentic benchmark below
    uses a 61k-token input, mirroring accumulated tool results.
-3. **Coding ability** — important, but a great coder that can't drive tools is useless here.
-4. **Instruction following** — permission modes, agent definitions, structured outputs.
-5. **Serveable footprint** — active params + quantization → GPU count → latency & cost; MoE models
-   are the sweet spot.
+4. **Coding ability** — important, but a great coder that can't drive tools is useless here, and the
+   hard part of this course is the harness, not the model's raw coding ceiling.
+5. **Instruction following** — permission modes, agent definitions, structured outputs.
+6. **Serveable footprint** — active params + quantization → GPU count → latency & cost; MoE models
+   are the sweet spot, which is exactly why a 35B-A3B model serves on one H100.
 
 **Hard disqualifier:** the model must serve through vLLM with a working **tool-call parser**
 (OpenAI/harmony for GPT-OSS, hermes/qwen for Qwen). Confirm under *Advanced Configurations*.
@@ -40,12 +52,18 @@ Workload "Agentic multi-turn" — input 61,278 tokens, output 1,521 tokens:
 
 | Model ID | GPU | Peak interactivity (tok/s/user) | Relative serve cost |
 |---|---|---|---|
+| `Qwen/Qwen3.6-35B-A3B-FP8` (course default) | **1×H100** | ~86 | **lowest** |
 | `openai/gpt-oss-120b` | **1×B200** | ~234 → 90 | medium |
-| `Qwen/Qwen3.6-35B-A3B-FP8` | **1×H100** | ~86 | **lowest** |
 | `zai-org/GLM-5.2-FP8` | **8×B200** | ~112–168 | **highest** (~8× the GPU at the priciest tier) |
 
-Cost intuition: for cheap dev, Qwen-on-H100 wins on absolute cost; for responsive real runs,
-GPT-OSS-on-one-B200 wins on cost-per-token; GLM is the premium option.
+How to read this: Qwen is the slowest per user and the cheapest by a wide margin — for a loop you
+are still building, waiting a few extra seconds per turn is the cheap resource and GPU-hours are the
+scarce one. GPT-OSS buys ~2–3× the interactivity for a real per-hour step up; take it once you are
+running the harness rather than writing it. GLM is the premium option — genuinely the most capable
+of the three on hard agentic tasks, and priced accordingly.
+
+Read the interactivity numbers as **relative**, not as a promise: they are Modal's own estimates,
+and one B200 vs one H100 is a hardware difference as much as a model one.
 
 ## Setting up an endpoint via the Modal CLI (Auto Endpoints)
 
@@ -67,8 +85,8 @@ distinct from the **endpoint/proxy** tokens below, which are how `decode` *calls
 ### Create the endpoint
 
 ```bash
-modal endpoint create --model openai/gpt-oss-120b --env main          # best fit
-modal endpoint create --model Qwen/Qwen3.6-35B-A3B-FP8 --env main    # cheap dev default
+modal endpoint create --model Qwen/Qwen3.6-35B-A3B-FP8 --env main    # best fit
+modal endpoint create --model openai/gpt-oss-120b --env main         # middle ground
 modal endpoint create --model zai-org/GLM-5.2-FP8 --env main         # max capability (8×B200)
 ```
 
@@ -108,7 +126,7 @@ Autoscaling is **dashboard-only**: **Min ≥ 1** = keep-warm (no cold starts, yo
 
 ```bash
 modal endpoint list --env main
-modal endpoint stop gpt-oss-120b --env main
+modal endpoint stop qwen3-6-35b-a3b-fp8 --env main
 ```
 
 ## Wiring an endpoint into `decode`
@@ -119,9 +137,9 @@ builds the model from settings:
 
 ```bash
 LLM_PROVIDER=modal
-MODAL_ENDPOINT_URL=https://...           # used as base_url = {url}/v1
-MODAL_ENDPOINT_MODEL=openai/gpt-oss-120b # served model id
-MODAL_PROXY_TOKEN_ID=wk-...              # optional — omit if --unauthenticated
+MODAL_ENDPOINT_URL=https://...                    # used as base_url = {url}/v1
+MODAL_ENDPOINT_MODEL=Qwen/Qwen3.6-35B-A3B-FP8     # served model id — course default
+MODAL_PROXY_TOKEN_ID=wk-...                       # optional — omit if --unauthenticated
 MODAL_PROXY_TOKEN_SECRET=ws-...
 ```
 
@@ -129,3 +147,9 @@ Auth nuance: Modal's proxy uses custom `Modal-Key` / `Modal-Secret` headers, not
 Bearer`. Both proxy tokens set → sent as default headers; neither set → no headers and a placeholder
 `api_key="EMPTY"`. The startup guard enforces both-or-neither, so a half-set pair is a friendly
 config error, not a silent 401.
+
+**Moving up the ladder costs two env vars.** Because every option here serves the same
+OpenAI-compatible surface, going from the Qwen default to GPT-OSS or GLM-5.2 means pointing
+`MODAL_ENDPOINT_URL` / `MODAL_ENDPOINT_MODEL` at the other endpoint — no harness change, no code
+change. Build against the default, then re-point at a bigger model when you want to see how far the
+same loop goes.


### PR DESCRIPTION
## Summary

Reframes `running_the_code/modal_models.md` around a **cost/capability ladder** instead of a single "best" model, with `Qwen/Qwen3.6-35B-A3B-FP8` as the best fit for working through the course.

| Pick | Model |
|---|---|
| Best fit — course default | `Qwen/Qwen3.6-35B-A3B-FP8` (1×H100) |
| Middle ground | `openai/gpt-oss-120b` (1×B200) |
| Max capability | `zai-org/GLM-5.2-FP8` (8×B200) |

## Changes

- **TL;DR table** reordered; notes the course is built and tested against the Qwen default.
- **Selection criteria** — adds "cost per learning iteration" as #2, explicitly flagged as course-specific ("on a production harness this criterion would rank last"). #1 softened so native OpenAI tool-call format is the *smoothest* option rather than the only passing one — Qwen clears the bar via the `hermes`/`qwen` parser.
- **Benchmark table** reordered with a "how to read this" paragraph naming the tradeoff directly, and a reminder the figures are Modal's estimates.
- **Examples** (`modal endpoint stop`, `MODAL_ENDPOINT_MODEL`) default to Qwen; new closing note that moving up the ladder is two env vars and no code change.

GPT-OSS keeps its credit for native OpenAI tool-call format and GLM-5.2 is still called the most capable — the doc argues Qwen is the best *fit for learning*, not the best model.

## Test plan

Docs only — no code or behavior change. Pre-commit format + lint passed on commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)