### PR TITLE
Redesign the landing page (index.html)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -8,7 +8,6 @@
 <meta name="author" content="Paul Iusztin — Decoding AI">
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 <link rel="canonical" href="https://building-a-coding-agent-from-scratch-course.decodingai.com/">
-
 <meta property="og:site_name" content="Decoding AI">
 <meta property="og:title" content="Building a Coding Agent From Scratch — Free Open-Source Course in Python">
 <meta property="og:description" content="The harness, not the model, makes a coding agent good. Build one from scratch, from a bare-bones agent loop to a swarm of cloud agents. 8 free lessons, $0 to run.">
@@ -17,689 +16,933 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:image" content="https://raw.githubusercontent.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/main/assets/github-repo-banner-dark.png">
 <meta property="og:image:alt" content="decode — a coding agent built from scratch, sponsored by Modal, Opik and Kitaru">
-
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Building a Coding Agent From Scratch — Free Open-Source Course in Python">
 <meta name="twitter:description" content="The harness, not the model, makes a coding agent good. Build one from scratch, from a bare-bones agent loop to a swarm of cloud agents. 8 free lessons, $0 to run.">
 <meta name="twitter:image" content="https://raw.githubusercontent.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/main/assets/github-repo-banner-dark.png">
-
 <link rel="icon" href="assets/coding-agent-logo.png">
-
+<script src="https://unpkg.com/lucide@1.28.0/dist/umd/lucide.min.js" integrity="sha384-VrnzGPiSyQxm3mI2VhlssyR85zugSHtxMkgO42qV3wUAbNk1oRdZkCWjXKOhuVu6" crossorigin="anonymous"></script>
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Course",
-  "name": "Building a Coding Agent From Scratch",
-  "description": "Build a coding agent from scratch in Python: the ReAct agent loop, tools, permissions, Docker and Modal sandboxes, durable runtime, context engineering, subagents and evals. 8 written lessons and 4 videos, free and open-source.",
-  "url": "https://building-a-coding-agent-from-scratch-course.decodingai.com/",
-  "inLanguage": "en",
-  "isAccessibleForFree": true,
-  "license": "https://www.apache.org/licenses/LICENSE-2.0",
-  "teaches": [
-    "Coding agent harness architecture",
-    "The ReAct agent loop with Pydantic AI",
-    "Agent tools: file I/O, bash, web, LSP",
-    "Permissions and sandboxing with Docker and Modal",
-    "Durable execution, human-in-the-loop and replays",
-    "Context engineering: memory, compaction, skills",
-    "Subagents and parallel fan-out",
-    "Benchmarks, regression and online AI evals"
-  ],
-  "provider": {
-    "@type": "Organization",
-    "name": "Decoding AI",
-    "url": "https://www.decodingai.com"
-  },
-  "author": {
-    "@type": "Person",
-    "name": "Paul Iusztin",
-    "url": "https://www.pauliusztin.ai/"
-  },
-  "hasCourseInstance": {
-    "@type": "CourseInstance",
-    "courseMode": "online",
-    "courseWorkload": "PT8H"
-  },
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "USD",
-    "availability": "https://schema.org/InStock",
-    "category": "Free"
-  }
-}
+{"@context":"https://schema.org","@type":"Course","name":"Building a Coding Agent From Scratch","description":"Build a coding agent from scratch in Python: the ReAct agent loop, tools, permissions, Docker and Modal sandboxes, durable runtime, context engineering, subagents and evals. 8 written lessons and 4 videos, free and open-source.","url":"https://building-a-coding-agent-from-scratch-course.decodingai.com/","inLanguage":"en","isAccessibleForFree":true,"license":"https://www.apache.org/licenses/LICENSE-2.0","teaches":["Coding agent harness architecture","The ReAct agent loop with Pydantic AI","Agent tools: file I/O, bash, web, LSP","Permissions and sandboxing with Docker and Modal","Durable execution, human-in-the-loop and replays","Context engineering: memory, compaction, skills","Subagents and parallel fan-out","Benchmarks, regression and online AI evals"],"provider":{"@type":"Organization","name":"Decoding AI","url":"https://www.decodingai.com"},"author":{"@type":"Person","name":"Paul Iusztin","url":"https://www.pauliusztin.ai/"},"hasCourseInstance":{"@type":"CourseInstance","courseMode":"online","courseWorkload":"PT8H"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD","availability":"https://schema.org/InStock","category":"Free"}}
 </script>
-
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Do I need a paid API key?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No. The default Gemini provider has a free tier, OpenRouter routes across :free models, and Modal gives $30 in credits."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Why Python and not TypeScript or Go?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Accessibility: our audience knows Python. The course focuses on the design decisions, which transfer to any language."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Why build from scratch instead of extending Pi, DeepAgents, or an existing harness?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Because adding custom logic to an existing harness is the easy part — knowing what to add requires understanding the internals. That's the fundamentals, and it's what still makes AI engineers valuable. Build a coding agent once and you're equipped to build a custom agent for any use case."
-      }
-    }
-  ]
-}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Do I need a paid API key?","acceptedAnswer":{"@type":"Answer","text":"No. The default Gemini provider has a free tier, OpenRouter routes across :free models, and Modal gives $30 in credits."}},{"@type":"Question","name":"Why Python and not TypeScript or Go?","acceptedAnswer":{"@type":"Answer","text":"Accessibility: our audience knows Python. The course focuses on the design decisions, which transfer to any language."}},{"@type":"Question","name":"Why build from scratch instead of extending Pi, DeepAgents, or an existing harness?","acceptedAnswer":{"@type":"Answer","text":"Because adding custom logic to an existing harness is the easy part — knowing what to add requires understanding the internals. That's the fundamentals, and it's what still makes AI engineers valuable. Build a coding agent once and you're equipped to build a custom agent for any use case."}}]}
 </script>
 <style>
-  :root {
-    --bg: #0a0e14;
-    --panel: #10161f;
-    --panel-2: #141c27;
-    --border: #1f2937;
-    --text: #d6dce6;
-    --muted: #8b98a9;
-    --green: #7ce38b;
-    --orange: #ffa657;
-    --blue: #58a6ff;
-    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  html { scroll-behavior: smooth; scroll-padding-top: 4.5rem; }
-  body { background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.65; }
-  a { color: var(--blue); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  img { max-width: 100%; height: auto; display: block; }
-  code { font-family: var(--mono); font-size: 0.92em; background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 0.1em 0.35em; }
-  .wrap { max-width: 1060px; margin: 0 auto; padding: 0 1.25rem; }
-  section { padding: 3.5rem 0; border-top: 1px solid var(--border); }
-  h2 { font-size: 1.7rem; margin-bottom: 1rem; }
-  h2 .hash { color: var(--green); font-family: var(--mono); margin-right: 0.4rem; }
-  h3 { font-size: 1.15rem; margin: 1.6rem 0 0.6rem; }
-  p + p { margin-top: 0.9rem; }
-  .muted { color: var(--muted); }
+*,*::before,*::after{box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{margin:0;background:#131314;font-family:'Open Sans',system-ui,sans-serif}
+img{max-width:100%;height:auto;display:block}
+[data-lucide]{display:inline-flex;flex:none}
+@media (max-width:1180px){
+  /* every inline white-space:nowrap is a desktop-only nicety — release it before it overflows */
+  [style*="nowrap"]:not(a){white-space:normal!important}
+  #top h1{font-size:clamp(28px,4.4vw,40px)!important}
+  #top>div>div>div>p:nth-of-type(1){font-size:clamp(17px,2vw,19px)!important}
+  #top>div>div>div>p:nth-of-type(2){font-size:clamp(15px,1.7vw,16.5px)!important}
+  #top>div>div>div>p:nth-of-type(3){font-size:13.5px!important}
+  #about h2{font-size:clamp(26px,3.6vw,38px)!important}
+}
+@media (max-width:820px){
+  #top>div>div{grid-template-columns:1fr!important}
+}
+@media (max-width:700px){
+  /* phones: every multi-column grid becomes one column */
+  [style*="grid-template-columns"]{grid-template-columns:1fr!important}
+  /* the section jump-links don't fit a phone; the GitHub button stays */
+  header nav a[href^="#"]{display:none!important}
+}
+</style>
+<style>
+/* ===== Decoding AI design tokens (inlined from the design system) ===== */
+/* ============================================================
+   DECODING AI — Colors & Type Foundations
+   Single source of truth for color + typography tokens.
+   Inlined into this page (originally colors_and_type.css).
+   ============================================================ */
 
-  /* nav */
-  nav { position: sticky; top: 0; z-index: 50; background: rgba(10,14,20,0.92); backdrop-filter: blur(8px); border-bottom: 1px solid var(--border); }
-  nav .wrap { display: flex; align-items: center; gap: 1.1rem; height: 3.4rem; }
-  nav .brand { display: flex; align-items: center; gap: 0.5rem; font-family: var(--mono); font-weight: 700; color: var(--text); }
-  nav .brand img { width: 26px; height: 26px; }
-  nav .links { margin-left: auto; display: flex; gap: 1rem; flex-wrap: wrap; font-size: 0.9rem; }
-  nav .links a { color: var(--muted); }
-  nav .links a:hover { color: var(--text); text-decoration: none; }
-  nav .gh { color: var(--green) !important; font-family: var(--mono); }
+/* --- Webfonts -------------------------------------------------
+   Open Sans is the brand typeface (per Branding.md).
+   JetBrains Mono is a SUBSTITUTE for code/monospace contexts
+   (no mono specified in the brand kit) — flagged in README.
+   Loaded from Google Fonts. To go fully offline, drop the .woff2
+   files into fonts/ and swap these @imports for @font-face.
+------------------------------------------------------------- */
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
-  /* hero */
-  header { text-align: center; padding: 4rem 0 2.5rem; }
-  header img.logo { width: 110px; margin: 0 auto 1.2rem; }
-  header h1 { font-size: clamp(1.9rem, 4.5vw, 3rem); line-height: 1.15; }
-  header .sub { font-size: clamp(1.05rem, 2.2vw, 1.35rem); color: var(--muted); max-width: 46rem; margin: 1rem auto 0; }
-  header .sub b { color: var(--text); }
-  .badges { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; margin-top: 1.3rem; }
-  .cta-row { display: flex; gap: 0.8rem; justify-content: center; flex-wrap: wrap; margin-top: 1.8rem; }
-  .btn { display: inline-block; padding: 0.7rem 1.4rem; border-radius: 8px; font-weight: 600; font-size: 1rem; }
-  .btn:hover { text-decoration: none; filter: brightness(1.12); }
-  .btn-primary { background: var(--green); color: #08110b; }
-  .btn-ghost { border: 1px solid var(--border); color: var(--text); background: var(--panel); }
-  .partners { margin-top: 1.4rem; font-size: 0.85rem; color: var(--muted); }
-  .hero-gif { margin: 2.4rem auto 0; max-width: 860px; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+:root {
+  /* ===== RAW PALETTE (from Branding.md) ====================== */
 
-  /* terminal block */
-  .term { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; margin: 1.4rem 0; }
-  .term-bar { display: flex; align-items: center; gap: 0.45rem; padding: 0.55rem 0.9rem; border-bottom: 1px solid var(--border); background: var(--panel-2); }
-  .term-bar span.dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
-  .term-bar .r { background: #ff5f57; } .term-bar .y { background: #febc2e; } .term-bar .g { background: #28c840; }
-  .term-bar .title { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin-left: 0.4rem; }
-  .term-bar button { margin-left: auto; background: none; border: 1px solid var(--border); color: var(--muted); font-family: var(--mono); font-size: 0.75rem; border-radius: 5px; padding: 0.2rem 0.6rem; cursor: pointer; }
-  .term-bar button:hover { color: var(--text); border-color: var(--muted); }
-  .term pre { padding: 1rem 1.1rem; overflow-x: auto; font-family: var(--mono); font-size: 0.88rem; line-height: 1.7; }
-  .term pre .c { color: var(--muted); }
-  .term pre .p { color: var(--green); }
-  code.block-note { border: none; background: none; padding: 0; }
+  /* Core neutrals */
+  --white:   #ffffff;
+  --grey:    #cdcfd3;   /* light cool silver-grey */
+  --black-1: #414042;   /* dark charcoal */
+  --black-2: #232527;   /* deep obsidian */
+  --black-3: #131314;   /* pitch black */
 
-  /* code snippet */
-  pre.code { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1.1rem 1.2rem; overflow-x: auto; font-family: var(--mono); font-size: 0.88rem; line-height: 1.7; margin: 1.2rem 0; }
-  pre.code .c { color: var(--muted); }
-  pre.code .k { color: var(--orange); }
-  pre.code .s { color: var(--green); }
+  /* Red family — "Punchy brick red" */
+  --red:    #d5342a;    /* base */
+  --red-1:  #b70000;    /* deep crimson / blood red */
+  --red-2:  #ec7c67;    /* soft warm coral */
+  --red-3:  #f59b87;    /* light flamingo pink */
+  --red-4:  #fbb9a9;    /* pale blush pink */
+  --red-5:  #ffd7cd;    /* soft shell pink pastel */
 
-  /* figures + galleries */
-  figure { margin: 1.8rem 0; text-align: center; }
-  figure img { border: 1px solid var(--border); border-radius: 10px; margin: 0 auto; }
-  figcaption { margin-top: 0.6rem; font-size: 0.88rem; color: var(--muted); }
-  figcaption b { color: var(--text); display: block; font-size: 0.95rem; margin-bottom: 0.15rem; }
-  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1.4rem; }
-  .grid2 figure { margin: 0; }
-  @media (max-width: 720px) { .grid2 { grid-template-columns: 1fr; } }
+  /* Orange family — "Warm tangerine orange" */
+  --orange:   #e58925;  /* base */
+  --orange-1: #c64b00;  /* deep burnt rust / terracotta */
+  --orange-2: #f3aa66;  /* soft cantaloupe */
+  --orange-3: #f9ba84;  /* warm peach / apricot */
+  --orange-4: #fdcba2;  /* light creamy salmon */
+  --orange-5: #ffdcc0;  /* pale bisque pastel */
 
-  /* cards */
-  .cards { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.6rem; }
-  @media (max-width: 720px) { .cards { grid-template-columns: 1fr; } }
-  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1.2rem 1.3rem; }
-  .card .num { font-family: var(--mono); color: var(--green); font-size: 0.85rem; }
-  .card h4 { font-size: 1.05rem; margin: 0.25rem 0 0.45rem; }
-  .card p { font-size: 0.92rem; color: var(--muted); }
-  .card figure { margin: 0.9rem 0 0.2rem; }
-  .card figure img { border-radius: 8px; }
-  .card .links { margin-top: 0.7rem; font-size: 0.85rem; font-family: var(--mono); display: flex; flex-wrap: wrap; gap: 0.35rem 0.9rem; }
-  .card .soon { color: var(--muted); font-size: 0.85rem; font-family: var(--mono); }
-  .card .live { color: var(--green); font-family: var(--mono); font-size: 0.85rem; }
+  /* Yellow family — "Vibrant sunflower yellow" */
+  --yellow:   #f9cf32;  /* base */
+  --yellow-1: #e8ba00;  /* deep goldenrod / mustard */
+  --yellow-2: #fad24c;  /* bright dandelion */
+  --yellow-3: #fbd661;  /* soft butter yellow */
+  --yellow-4: #fcdd88;  /* light golden blonde */
+  --yellow-5: #fce09a;  /* pale vanilla pastel */
 
-  /* lists */
-  ul.checks { list-style: none; margin-top: 1rem; }
-  ul.checks li { padding-left: 1.6rem; position: relative; margin-bottom: 0.55rem; }
-  ul.checks li::before { content: "▸"; position: absolute; left: 0.2rem; color: var(--green); font-family: var(--mono); }
-  ul.checks b { color: var(--text); }
+  /* ===== GRADIENTS ========================================== */
+  /* Warm Brand Gradient — the signature. Red → Orange.
+     Used in the wordmark and as the primary expressive accent. */
+  --gradient-warm: linear-gradient(90deg, var(--red) 0%, var(--orange) 100%);
+  --gradient-warm-diag: linear-gradient(120deg, var(--red-1) 0%, var(--red) 38%, var(--orange) 100%);
+  /* Dark Brand Gradient — smooth blend across Black 3 → Black 2 → Black 1 (per Branding.md) */
+  --gradient-dark: linear-gradient(160deg, var(--black-3) 0%, var(--black-2) 50%, var(--black-1) 100%);
 
-  /* tables */
-  .tbl-wrap { overflow-x: auto; margin-top: 1.2rem; }
-  table.tbl { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
-  table.tbl th, table.tbl td { border: 1px solid var(--border); padding: 0.6rem 0.85rem; text-align: left; vertical-align: top; }
-  table.tbl th { background: var(--panel-2); }
-  table.tbl td { background: var(--panel); }
+  /* ===== SEMANTIC TOKENS — LIGHT (default) ================== */
+  --bg:           var(--white);        /* page background */
+  --surface:      #ffffff;             /* cards / raised surfaces */
+  --surface-2:    #f6f7f8;             /* subtle filled panels */
+  --surface-3:    #eef0f2;             /* inset wells */
+  --fg:           var(--black-3);      /* primary text */
+  --fg-2:         var(--black-1);      /* secondary text */
+  --fg-3:         #6b6c6f;             /* muted / captions */
+  --fg-on-accent: var(--white);        /* text on warm/red fills */
+  --border:       #e3e5e8;             /* hairline dividers */
+  --border-strong:#cdcfd3;             /* input borders */
+  --ring:         color-mix(in oklch, var(--red) 45%, transparent); /* focus ring */
 
-  /* faq */
-  details { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 0.9rem 1.2rem; margin-top: 0.7rem; }
-  details summary { cursor: pointer; font-weight: 600; }
-  details p { margin-top: 0.7rem; color: var(--muted); font-size: 0.95rem; }
+  /* Brand roles */
+  --primary:        var(--red);
+  --primary-hover:  #c12a21;           /* darker red for hover */
+  --primary-press:  var(--red-1);      /* deepest red for press */
+  --accent:         var(--orange);
+  --accent-hover:   #d2781b;
+  --highlight:      var(--yellow);     /* highlights / marks */
 
-  /* author + footer */
-  .author { display: flex; gap: 1.2rem; align-items: center; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1.3rem; margin-top: 1.4rem; }
-  .author .who { text-align: center; flex-shrink: 0; }
-  .author img { width: 84px; height: 84px; border-radius: 50%; border: 1px solid var(--border); }
-  .author .who b { display: block; margin-top: 0.5rem; font-size: 0.95rem; }
-  .author p { font-size: 0.93rem; color: var(--muted); }
-  @media (max-width: 620px) { .author { flex-direction: column; text-align: center; } }
-  footer { border-top: 1px solid var(--border); padding: 2.5rem 0 3.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
-  .newsletter { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1.6rem; text-align: center; margin-top: 1.6rem; }
+  /* Status (built on brand families + harmonious additions) */
+  /* Warm-only severity ramp — the brand palette has NO green.
+     Positive/confirmation states use gold + a check mark, not green. */
+  --danger:  var(--red-1);      /* error / destructive */
+  --warning: var(--orange-1);   /* caution */
+  --success: var(--yellow-1);   /* positive / confirmed — gold, no green in palette */
+  --info:    var(--black-1);
+
+  /* ===== TYPE ============================================== */
+  --font-sans: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  /* Display = Open Sans at its heaviest, very tight, all-caps — echoes
+     the geometric wordmark. The wordmark itself is custom lettering:
+     use the logo image, never re-typeset "DECODING AI". */
+  --font-display: 'Open Sans', sans-serif;
+
+  /* Fluid type scale (1.250 major-third) */
+  --text-xs:   0.75rem;   /* 12 */
+  --text-sm:   0.875rem;  /* 14 */
+  --text-base: 1rem;      /* 16 */
+  --text-lg:   1.125rem;  /* 18 */
+  --text-xl:   1.375rem;  /* 22 */
+  --text-2xl:  1.75rem;   /* 28 */
+  --text-3xl:  2.25rem;   /* 36 */
+  --text-4xl:  3rem;      /* 48 */
+  --text-5xl:  4rem;      /* 64 */
+  --text-6xl:  5.25rem;   /* 84 */
+
+  --weight-light: 300;
+  --weight-regular: 400;
+  --weight-medium: 600;   /* Open Sans semibold reads as the UI "medium" */
+  --weight-bold: 700;
+  --weight-black: 800;
+
+  --leading-tight: 1.05;
+  --leading-snug: 1.2;
+  --leading-normal: 1.55;
+  --leading-relaxed: 1.7;
+
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.04em;
+  --tracking-caps: 0.08em;   /* eyebrows / all-caps labels */
+
+  /* ===== RADII / SHADOW / SPACING ========================== */
+  --radius-xs: 4px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --radius-xl: 28px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(19,19,20,0.06), 0 1px 3px rgba(19,19,20,0.08);
+  --shadow-md: 0 4px 10px rgba(19,19,20,0.07), 0 2px 4px rgba(19,19,20,0.06);
+  --shadow-lg: 0 14px 34px rgba(19,19,20,0.12), 0 4px 10px rgba(19,19,20,0.08);
+  --shadow-warm: 0 10px 30px rgba(213,52,42,0.28);  /* glow under primary CTAs */
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
+}
+
+/* ===== DARK THEME =========================================== */
+/* Add data-theme="dark" to <html> or any container. */
+[data-theme="dark"] {
+  --bg:           var(--black-3);
+  --surface:      #1b1c1e;
+  --surface-2:    var(--black-2);
+  --surface-3:    #2c2e30;
+  --fg:           #f3f3f4;
+  --fg-2:         #c9cace;
+  --fg-3:         #8a8c90;
+  --fg-on-accent: var(--white);
+  --border:       #2e3033;
+  --border-strong:#3a3d40;
+  --ring:         color-mix(in oklch, var(--orange) 55%, transparent);
+
+  --primary:       var(--red);
+  --primary-hover: #e0463c;
+  --primary-press: var(--red-2);
+  --accent:        var(--orange);
+  --accent-hover:  #f0973a;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.5);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.5);
+  --shadow-lg: 0 18px 40px rgba(0,0,0,0.6);
+  --shadow-warm: 0 12px 36px rgba(213,52,42,0.45);
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT STYLES
+   Optional base layer — gives raw HTML the brand voice.
+   ============================================================ */
+.ds-scope, .ds-body {
+  font-family: var(--font-sans);
+  color: var(--fg);
+  background: var(--bg);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.ds-scope h1, .h1 {
+  font-size: var(--text-5xl);
+  font-weight: var(--weight-black);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg);
+}
+.ds-scope h2, .h2 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-tight);
+}
+.ds-scope h3, .h3 {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-snug);
+}
+.ds-scope h4, .h4 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+}
+.ds-scope p, .body {
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+  color: var(--fg-2);
+}
+.lead {
+  font-size: var(--text-lg);
+  line-height: var(--leading-relaxed);
+  color: var(--fg-2);
+}
+.small, .caption {
+  font-size: var(--text-sm);
+  color: var(--fg-3);
+}
+/* Eyebrow / kicker — the brand's signature all-caps label */
+.eyebrow {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--primary);
+}
+code, kbd, samp, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+/* Warm gradient applied to text (e.g. headline accents, the wordmark feel) */
+.text-gradient {
+  background: var(--gradient-warm);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+</style>
+<style>
+a{color:var(--primary)}
+a:hover{color:var(--primary-hover)}
+/* hover / focus states lifted from inline style rules */
+.x1:hover{color:var(--primary)!important;background:var(--surface-2)!important}
+.x2:hover{background:var(--surface-2)!important}
+.x3:active{transform:scale(.97)!important}
+.x4:hover{background:rgba(255,255,255,.16)!important}
+.x5:hover{border-color:var(--border-strong)!important;transform:translateY(-3px)!important;box-shadow:var(--shadow-lg)!important}
+.x6:hover{color:var(--fg)!important}
+.x7:hover{background:var(--surface)!important;border-color:var(--fg-3)!important}
+.x8:hover{color:var(--primary)!important}
+.x9:hover{border-color:var(--border-strong)!important;transform:translateY(-2px)!important}
+.x10:hover{background:var(--surface)!important}
+.x11:hover{border-color:var(--border-strong)!important}
 </style>
 </head>
 <body>
+<div class="ds-scope" data-theme="dark" style="background:var(--bg);min-height:100vh">
 
-<nav>
-  <div class="wrap">
-    <a class="brand" href="#top">
-      <img src="assets/coding-agent-logo.png" alt=""> decode
-    </a>
-    <div class="links">
-      <a href="#about">About</a>
-      <a href="#see-it-work">See It Work</a>
-      <a href="#outline">Outline</a>
-      <a href="#cost">Cost</a>
-      <a href="#running">Running the Code</a>
-      <a href="#faq">FAQ</a>
-      <a class="gh" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener">★ GitHub</a>
-    </div>
-  </div>
+<header style="position:sticky;top:0;z-index:60;padding:0 clamp(20px,3vw,40px);background:rgba(19,19,20,.82);backdrop-filter:saturate(160%) blur(14px);-webkit-backdrop-filter:saturate(160%) blur(14px);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto;height:66px;display:flex;align-items:center;gap:24px">
+<a href="#top" style="display:flex;align-items:center;gap:10px;text-decoration:none;flex:none">
+<img src="assets/coding-agent-logo.png" alt="" style="width:28px;height:28px">
+<span style="font-family:var(--font-mono);font-size:15px;font-weight:700;color:var(--fg);letter-spacing:-.01em">decode</span>
+</a>
+<nav style="margin-left:auto;display:flex;align-items:center;gap:2px">
+<a class="x1" href="#about" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">About</a>
+<a class="x1" href="#curriculum" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">Outline</a>
+<a class="x1" href="#see-it-work" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">See it work</a>
+<a class="x1" href="#cost" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">Cost</a>
+<a class="x1" href="#running" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">Run it</a>
+<a class="x1" href="#faq" style="font-size:13.5px;font-weight:600;color:var(--fg-2);padding:8px 12px;border-radius:var(--radius-pill);text-decoration:none">FAQ</a>
+<span style="width:8px"></span>
+<a class="x2" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:700;color:var(--fg);border:1.5px solid var(--border-strong);border-radius:var(--radius-pill);padding:8px 15px;text-decoration:none;transition:background .15s"><i data-lucide="star" style="width:14px;height:14px"></i>GitHub</a>
 </nav>
-
-<header id="top">
-  <div class="wrap">
-    <img class="logo" src="assets/coding-agent-logo.png" alt="decode logo">
-    <h1>Building a Coding Agent From&nbsp;Scratch</h1>
-    <p class="sub"><b>The harness, not the model, makes a coding agent good.</b> Build one from scratch, from a bare-bones agent loop to a swarm of cloud agents.</p>
-    <div class="badges">
-      <img src="https://img.shields.io/badge/type-open--source_course-8a2be2" alt="Open-source course">
-      <img src="https://img.shields.io/badge/cost_to_run-%240-2ea44f" alt="$0 to run">
-      <img src="https://img.shields.io/badge/articles-8-4c8eda" alt="8 articles">
-      <img src="https://img.shields.io/badge/videos-4-ff0000" alt="4 videos">
-      <img src="https://img.shields.io/badge/code-from_scratch-orange" alt="Code from scratch">
-      <img src="https://img.shields.io/badge/license-Apache--2.0-lightgrey" alt="Apache-2.0 license">
-    </div>
-    <div class="cta-row">
-      <a class="btn btn-primary" href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener">Start Lesson 1 →</a>
-      <a class="btn btn-ghost" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener">Star the repo</a>
-    </div>
-    <p class="partners">Open-source course by <a href="https://www.decodingai.com">Decoding AI</a> in collaboration with <a href="https://modal.com?source=decodingai&campaign=harnesseng">Modal</a>, <a href="https://www.comet.com/site/?utm_source=workshop&utm_medium=partner&utm_campaign=paul&utm_content=coding_agent_course">Opik (by Comet)</a> and <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&utm_medium=referral&utm_campaign=coding-agent-course&utm_content=brand">Kitaru (by ZenML)</a>.</p>
-    <div class="hero-gif"><img src="assets/demo-frames.gif" alt="decode in the terminal"></div>
-  </div>
+</div>
 </header>
 
-<section id="quickstart" style="border-top:none; padding-top:1rem;">
-  <div class="wrap">
-    <h2><span class="hash">$</span>Try the finished agent first — 5 minutes, $0</h2>
-    <div class="term">
-      <div class="term-bar">
-        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-        <span class="title">quickstart.sh</span>
-        <button id="copy-btn" type="button">copy</button>
-      </div>
-      <pre id="quickstart-code"><span class="p">$</span> git clone https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course.git
-<span class="p">$</span> cd building-a-coding-agent-from-scratch-course
-<span class="p">$</span> make install
-<span class="p">$</span> cp .env.example .env   <span class="c"># set LLM API key</span>
-<span class="p">$</span> uv run decode</pre>
-    </div>
-    <p>Then type <code>/demo-</code> and pick a demo — <a href="#see-it-work">see what they do</a> below. <a href="#running">Full setup guide.</a></p>
-    <figure>
-      <img src="assets/demo-skills.png" alt="The demo skills listed inside the decode TUI after typing /demo-" style="max-width:820px">
-      <figcaption>Type <code>/demo-</code> and the six demos are one keystroke away.</figcaption>
-    </figure>
-  </div>
+<section id="top" style="position:relative;overflow:hidden;background:var(--gradient-dark);color:#fff;padding:clamp(48px,7vw,84px) clamp(20px,3vw,40px) clamp(40px,6vw,68px)">
+<div style="position:relative;max-width:1320px;margin:0 auto">
+<div style="display:grid;grid-template-columns:1.1fr 1fr;gap:clamp(24px,3vw,44px);align-items:center">
+<div style="min-width:0">
+<div style="display:flex;align-items:center;gap:11px;margin:0 0 clamp(20px,3vh,28px)">
+<img src="assets/coding-agent-logo.png" alt="decode logo" style="width:60px;height:60px;flex:none">
+<span style="font-family:var(--font-mono);font-size:15px;font-weight:700;color:#fff;letter-spacing:-.01em">decode</span>
+<span style="width:1px;height:16px;background:rgba(255,255,255,.22);flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--orange)">Free open-source course</span>
+</div>
+<h1 style="font-size:min(2.5vw,32px);font-weight:700;line-height:1.1;letter-spacing:-.03em;margin:0;color:#fff;white-space:nowrap">Building a Coding Agent <span style="color:#fff">From Scratch</span></h1>
+<p style="font-size:min(1.4vw,19px);line-height:1.5;color:#fff;font-weight:700;margin:clamp(14px,2.2vh,20px) 0 0;white-space:nowrap">The harness, not the model, makes a coding agent good.</p>
+<p style="font-size:min(1.06vw,14.5px);line-height:1.62;color:#9a9ca1;margin:8px 0 0;white-space:nowrap">Build one from scratch, from a bare-bones agent loop to a swarm of cloud agents.</p>
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:12px;margin:clamp(24px,3.6vh,34px) 0 0">
+<a class="x3" href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:9px;font-size:15px;font-weight:700;color:#fff;background:var(--gradient-warm);border:none;border-radius:var(--radius-pill);padding:14px 26px;text-decoration:none;transition:transform .15s cubic-bezier(.2,.8,.2,1)">Start Lesson 1 <i data-lucide="arrow-right" style="width:16px;height:16px"></i></a>
+<a class="x4" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:8px;font-size:15px;font-weight:700;color:#fff;background:rgba(255,255,255,.08);border:1.5px solid rgba(255,255,255,.22);border-radius:var(--radius-pill);padding:13px 24px;text-decoration:none;transition:background .15s"><i data-lucide="star" style="width:16px;height:16px"></i>Star the repo</a>
+</div>
+<p style="font-size:min(1vw,13px);line-height:1.6;color:#8a8c90;margin:clamp(16px,2.4vh,22px) 0 0;white-space:nowrap">By <a href="https://www.decodingai.com" style="color:var(--orange);text-decoration:none">Decoding AI</a>, in collaboration with <a href="https://modal.com/?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--orange);text-decoration:none">Modal</a>, <a href="https://www.comet.com/site/?utm_source=workshop&amp;utm_medium=partner&amp;utm_campaign=paul&amp;utm_content=coding_agent_course" target="_blank" rel="noopener" style="color:var(--orange);text-decoration:none">Opik</a> (by Comet), and <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&amp;utm_medium=referral&amp;utm_campaign=coding-agent-course&amp;utm_content=brand" target="_blank" rel="noopener" style="color:var(--orange);text-decoration:none">Kitaru</a> (by ZenML).</p>
+</div>
+<div style="position:relative;min-width:0">
+<div style="position:absolute;inset:8% -4% -6% 6%;background:radial-gradient(ellipse at center, rgba(213,52,42,.34), transparent 70%);filter:blur(18px);pointer-events:none"></div>
+<div style="position:relative;background:var(--black-3);border:1px solid rgba(255,255,255,.14);border-radius:var(--radius-lg);overflow:hidden;box-shadow:0 30px 70px rgba(0,0,0,.58)">
+<div style="display:flex;align-items:center;gap:7px;padding:11px 15px;background:rgba(255,255,255,.045);border-bottom:1px solid rgba(255,255,255,.08)">
+<span style="width:10px;height:10px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:10px;height:10px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:10px;height:10px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11.5px;color:#8a8c90;margin-left:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">decode — the finished agent</span>
+</div>
+<img src="assets/demo-frames.gif" alt="decode in the terminal" style="width:100%">
+</div>
+</div>
+</div>
+<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px 28px;margin:clamp(30px,4.6vh,48px) 0 0;padding:clamp(16px,2.4vh,22px) 0 0;border-top:1px solid rgba(255,255,255,.10)">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:6px">
+<img src="https://img.shields.io/badge/type-open--source_course-8a2be2" alt="Open-source course" style="height:20px;width:auto">
+<img src="https://img.shields.io/badge/cost_to_run-%240-2ea44f" alt="$0 to run" style="height:20px;width:auto">
+<img src="https://img.shields.io/badge/articles-8-4c8eda" alt="8 articles" style="height:20px;width:auto">
+<img src="https://img.shields.io/badge/videos-4-ff0000" alt="4 videos" style="height:20px;width:auto">
+<img src="https://img.shields.io/badge/code-from_scratch-orange" alt="Code from scratch" style="height:20px;width:auto">
+<img src="https://img.shields.io/badge/license-Apache--2.0-lightgrey" alt="Apache-2.0 license" style="height:20px;width:auto">
+</div>
+</div>
+</div>
 </section>
 
-<section id="about">
-  <div class="wrap">
-    <h2><span class="hash">##</span>About This Course</h2>
-    <p>In <a href="https://www.langchain.com/blog/the-anatomy-of-an-agent-harness" target="_blank" rel="noopener">LangChain's Terminal-Bench experiment</a>, changing only the harness (with the same model) moved a coding agent from ~30th place into the top 5: the harness, not the model, is what makes a coding agent good.</p>
-
-    <h3>The agent is ~20 lines. The course is everything else.</h3>
-<pre class="code">agent = Agent(
-    build_model(settings.llm_provider),        <span class="c"># gemini | openrouter | modal</span>
-    deps_type=AgentDeps,                       <span class="c"># cwd, event sink, permission gate</span>
-    output_type=[str, DeferredToolRequests],   <span class="c"># final answer, or tools paused for approval</span>
-)
-register_tools(agent)                          <span class="c"># read, edit, bash, grep, ...</span>
-
-<span class="k">async with</span> agent.iter(prompt, message_history=history) <span class="k">as</span> run:
-    <span class="k">async for</span> node <span class="k">in</span> run:                     <span class="c"># model request → tool calls → repeat</span>
-        stream_events(node)</pre>
-    <p>That's the <i>entire</i> tool-calling agent — the thing people call "the agent" ends here. Everything else in this repo — the tools, skills, the permission layer, sandbox, steering queue, memory, compaction, durable runtime, remote execution, the subagent fan-out, the evals — is the harness. That's what you're here to build.</p>
-
-    <figure>
-      <img src="assets/tui-session-start.png" alt="A fresh decode session: Opik tracing on, a Modal-served Qwen model, skill autocomplete, steering keys in the footer">
-      <figcaption>A fresh session powered by Qwen 3.6 35B hosted on Modal</figcaption>
-    </figure>
-
-    <p>We spent months under the hood of Claude Code (via its leaked source), <a href="https://github.com/anomalyco/opencode" target="_blank" rel="noopener">OpenCode</a>, <a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener">Pi</a>, and <a href="https://github.com/aider-ai/aider" target="_blank" rel="noopener">Aider</a>, then distilled it into 8 articles and 4 videos where you'll build <b>decode</b>, your own coding agent, from scratch — one headless core hooked to two modes: an interactive TUI and a remote runtime running N copies in parallel.</p>
-
-    <figure>
-      <img src="assets/architecture.png" alt="decode architecture" style="max-width:640px">
-      <figcaption>Two interface modes on the left, the headless harness on the right, the evals plane underneath.</figcaption>
-    </figure>
-  </div>
+<section id="quickstart" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Quickstart</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">01</span></div>
+<div style="display:flex;flex-wrap:wrap;align-items:baseline;justify-content:space-between;gap:12px 24px;margin:12px 0 clamp(20px,3vh,30px)">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;text-wrap:pretty">Try The Finished Agent First.</h2>
+<div style="display:flex;align-items:baseline;gap:10px;font-family:var(--font-mono);font-size:12px;color:var(--fg-3);flex:none">
+<span>5 minutes</span>
+<span style="color:var(--border-strong)">/</span>
+<span style="color:var(--accent);font-weight:700">$0</span>
+</div>
+</div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(16px,2vw,24px);align-items:stretch">
+<div style="min-width:0;display:flex;flex-direction:column">
+<div style="flex:1;min-height:0;display:flex;flex-direction:column;background:var(--black-3);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-lg)">
+<div style="display:flex;align-items:center;gap:7px;padding:10px 14px;background:rgba(255,255,255,.04);border-bottom:1px solid rgba(255,255,255,.07)">
+<span style="width:11px;height:11px;border-radius:50%;background:#ff5f57"></span>
+<span style="width:11px;height:11px;border-radius:50%;background:#febc2e"></span>
+<span style="width:11px;height:11px;border-radius:50%;background:#28c840"></span>
+<span style="font-family:var(--font-mono);font-size:11.5px;color:#8a8c90;margin-left:6px">quickstart.sh</span>
+<button class="x3" type="button" id="om-copy-btn" style="margin-left:auto;display:inline-flex;align-items:center;gap:7px;font-family:var(--font-sans);font-size:12.5px;font-weight:700;color:#fff;background:var(--gradient-warm);border:none;border-radius:var(--radius-pill);padding:7px 14px;cursor:pointer;transition:transform .15s cubic-bezier(.2,.8,.2,1)"><i data-lucide="copy" style="width:13px;height:13px"></i><span data-om-copy-label="true">copy</span></button>
+</div>
+<pre style="flex:1;margin:0;padding:20px 22px;overflow-x:auto;font-family:var(--font-mono);font-size:13px;line-height:1.85;color:#f3f3f4;display:grid;gap:0;align-content:center"><div><span style="color:var(--orange)">$</span> git clone https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course.git</div><div><span style="color:var(--orange)">$</span> cd building-a-coding-agent-from-scratch-course</div><div><span style="color:var(--orange)">$</span> make install</div><div><span style="color:var(--orange)">$</span> cp .env.example .env   <span style="color:#6b6c6f"># set LLM API key</span></div><div><span style="color:var(--orange)">$</span> uv run decode</div></pre>
+</div>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:18px 0 0">Then type <span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);background:var(--surface-2);border:1px solid var(--border);border-radius:4px;padding:2px 6px">/demo-</span> and pick a demo — <a href="#see-it-work" style="color:var(--primary);text-decoration:none">see what they do</a> below. <a href="#running" style="color:var(--primary);text-decoration:none">Full setup guide.</a></p>
+</div>
+<div style="position:relative">
+<div style="position:absolute;inset:8% -4% -6% 6%;background:radial-gradient(ellipse at center, rgba(213,52,42,.34), transparent 70%);filter:blur(18px);pointer-events:none"></div>
+<div style="position:relative;background:var(--black-3);border:1px solid rgba(255,255,255,.14);border-radius:var(--radius-lg);overflow:hidden;box-shadow:0 30px 70px rgba(0,0,0,.58)">
+<div style="display:flex;align-items:center;gap:7px;padding:11px 15px;background:rgba(255,255,255,.045);border-bottom:1px solid rgba(255,255,255,.08)">
+<span style="width:10px;height:10px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:10px;height:10px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:10px;height:10px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11.5px;color:#8a8c90;margin-left:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">decode — /demo-</span>
+</div>
+<img src="assets/demo-skills.png" alt="The demo skills listed inside the decode TUI after typing /demo-" style="width:100%">
+<div style="padding:14px 18px;border-top:1px solid rgba(255,255,255,.08);font-size:13px;line-height:1.55;color:#8a8c90">Type <span style="font-family:var(--font-mono);font-size:12.5px;color:#c9cacd">/demo-</span> and the six demos are one keystroke away.</div>
+</div>
+</div>
+</div>
+</div>
 </section>
 
-<section id="see-it-work">
-  <div class="wrap">
-    <h2><span class="hash">##</span>See It Work</h2>
-    <p>The finished agent ships with demo skills under <code>.decode/skills/</code>. Open the TUI, type <code>/demo-</code>, pick one, and watch the harness you're about to build do real work:</p>
+<section id="about" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">About this course</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">02</span></div>
+<h2 style="font-size:min(3.2vw,41px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:clamp(18px,2.6vh,26px) 0 0;white-space:nowrap">The Agent Is <span style="font-weight: normal;">~</span>20 Lines. The Course Is Everything Else.</h2>
+<p style="font-size:min(1.3vw,18px);line-height:1.6;color:var(--fg-2);margin:clamp(14px,2.2vh,20px) 0 0;white-space:nowrap">In <a href="https://www.langchain.com/blog/the-anatomy-of-an-agent-harness" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">LangChain's Terminal-Bench test</a>, changing only the harness moved an agent from ~30th to top 5. The harness, not the model, wins.</p>
 
-    <figure>
-      <img src="assets/demo-skills.png" alt="The demo skills listed inside the decode TUI after typing /demo-" style="max-width:880px">
-      <figcaption><b>Implement the Skills Standard</b>Type <code>/demo-</code> and the six demos are one keystroke away.</figcaption>
-    </figure>
+<div style="display:grid;grid-template-columns:1.15fr .85fr;gap:clamp(20px,2.8vw,36px);align-items:center;margin:clamp(30px,5vh,52px) 0 0">
+<div style="order:2;min-width:0">
+<p style="font-size:15.5px;line-height:1.7;color:var(--fg-2);margin:0">That's the <i>entire</i> tool-calling agent. Everything else in this repo is the harness: tools, skills, permissions, sandbox, steering, memory, compaction, durable runtime, subagents, evals.</p>
+<p style="font-size:15.5px;line-height:1.7;color:var(--fg);font-weight:700;margin:14px 0 0">That's what you're here to build.</p>
+</div>
+<div style="order:1;min-width:0;background:var(--black-3);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-md)">
+<div style="display:flex;align-items:center;gap:7px;padding:10px 14px;background:rgba(255,255,255,.04);border-bottom:1px solid rgba(255,255,255,.07)">
+<span style="width:9px;height:9px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11px;color:#8a8c90;margin-left:6px">the entire agent</span>
+</div>
+<pre style="margin:0;padding:22px 24px;overflow-x:auto;font-family:var(--font-mono);font-size:12.5px;line-height:1.8;color:#f3f3f4;display:grid;gap:0"><div>agent = Agent(</div><div>    build_model(settings.llm_provider),        <span style="color:#6b6c6f"># gemini | openrouter | modal</span></div><div>    deps_type=AgentDeps,                       <span style="color:#6b6c6f"># cwd, event sink, permission gate</span></div><div>    output_type=[str, DeferredToolRequests],   <span style="color:#6b6c6f"># final answer, or tools paused for approval</span></div><div>)</div><div>register_tools(agent)                          <span style="color:#6b6c6f"># read, edit, bash, grep, ...</span></div><div>&nbsp;</div><div><span style="color:var(--orange)">async with</span> agent.iter(prompt, message_history=history) <span style="color:var(--orange)">as</span> run:</div><div>    <span style="color:var(--orange)">async for</span> node <span style="color:var(--orange)">in</span> run:                     <span style="color:#6b6c6f"># model request → tool calls → repeat</span></div><div>        stream_events(node)</div></pre>
+</div>
+</div>
 
-    <div class="grid2" style="margin-top:1.8rem;">
-      <figure>
-        <img src="assets/demo-snake-game.png" alt="A playable Snake game built by decode">
-        <figcaption><b>Capable of Creating Games</b><code>/demo-1-terminal-arcade</code> — one prompt, a playable Snake game</figcaption>
-      </figure>
-      <figure>
-        <img src="assets/demo-repo-pulse.png" alt="Live GitHub repo data rendered as a web dashboard">
-        <figcaption><b>Fetching Data &amp; Creating Dashboards</b><code>/demo-3-repo-pulse</code> — live GitHub API data rendered as a dashboard</figcaption>
-      </figure>
-    </div>
-    <figure>
-      <img src="assets/demo-knowledge-graph.png" alt="An interactive knowledge graph scraped from web articles" style="max-width:880px">
-      <figcaption><b>Extracting Ontologies &amp; Rendering Graphs</b><code>/demo-6-article-kg</code> — web articles scraped into an interactive knowledge graph</figcaption>
-    </figure>
+<p style="font-size:clamp(16px,1.45vw,19px);line-height:1.62;color:var(--fg-2);margin:clamp(28px,4.4vh,44px) 0 0;text-wrap:pretty">We spent months inside Claude Code (via its leaked source), <a href="https://github.com/anomalyco/opencode" target="_blank" rel="noopener" style="color: var(--primary); text-decoration: none;">OpenCode</a>, <a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener" style="color: var(--primary); text-decoration: none;">Pi</a>, and <a href="https://github.com/aider-ai/aider" target="_blank" rel="noopener" style="color: var(--primary); text-decoration: none;">Aider</a>, then distilled it into 8 articles and 4 videos where you'll build <b style="color: var(--fg);">decode</b>, your own coding agent, from scratch: one headless core, two modes, N agents in parallel.</p>
 
-    <p style="margin-top:2.2rem;">And the infra that powers the agents:</p>
-
-    <div class="grid2" style="margin-top:1.8rem;">
-      <figure>
-        <img src="assets/kitaru-replay.png" alt="A durable run recorded step by step in Kitaru">
-        <figcaption><b>Durability &amp; Replay for AI Agents</b>Every run recorded step by step in <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&utm_medium=referral&utm_campaign=coding-agent-course&utm_content=brand" target="_blank" rel="noopener">Kitaru</a> — kill it, resume it, replay it with the model swapped</figcaption>
-      </figure>
-      <figure>
-        <img src="assets/modal-sandboxes.png" alt="Live Modal sandboxes executing the agent's tools">
-        <figcaption><b>Remote Sandboxing</b>The agent's <code>bash</code> runs in disposable <a href="https://modal.com/docs/guide/sandboxes?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal sandboxes</a></figcaption>
-      </figure>
-      <figure>
-        <img src="assets/modal-open-model.png" alt="A self-served open model endpoint on Modal">
-        <figcaption><b>Powered by Open Source Models</b>Your own Qwen3.6-35B served on an H200 via a <a href="https://modal.com/docs/guide/endpoints?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal endpoint</a></figcaption>
-      </figure>
-      <figure>
-        <img src="assets/opik-threads.png" alt="Sessions traced in Opik with secrets scrubbed">
-        <figcaption><b>Adding AI Evals &amp; Observability</b>Every session traced in <a href="https://www.comet.com/site/?utm_source=workshop&utm_medium=partner&utm_campaign=paul&utm_content=coding_agent_course" target="_blank" rel="noopener">Opik</a></figcaption>
-      </figure>
-    </div>
-  </div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(16px,2vw,24px);margin:clamp(22px,3.4vh,34px) 0 0">
+<figure class="x5" style="margin:0;min-width:0;background:var(--black-3);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-md);display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="display:flex;align-items:center;gap:7px;padding:10px 14px;background:rgba(255,255,255,.04);border-bottom:1px solid rgba(255,255,255,.07)">
+<span style="width:9px;height:9px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11px;color:#8a8c90;margin-left:6px">a fresh session</span>
+</div>
+<div style="flex:1;display:flex;align-items:center;justify-content:center;background:#242835"><img src="assets/tui-session-start.png" alt="A fresh decode session: Opik tracing on, a Modal-served Qwen model, skill autocomplete, steering keys in the footer" style="width:100%;height:auto;display:block"></div>
+<figcaption style="padding:14px 18px;border-top:1px solid rgba(255,255,255,.07);font-size:13px;line-height:1.55;color:#8a8c90">A fresh session powered by Qwen 3.6 35B hosted on Modal</figcaption>
+</figure>
+<figure class="x5" style="margin:0;min-width:0;background:var(--black-3);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-md);display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="display:flex;align-items:center;gap:7px;padding:10px 14px;background:rgba(255,255,255,.04);border-bottom:1px solid rgba(255,255,255,.07)">
+<span style="width:9px;height:9px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11px;color:#8a8c90;margin-left:6px">the architecture</span>
+</div>
+<div style="flex:1;display:flex;align-items:center;justify-content:center"><img src="assets/architecture.png" alt="decode architecture" style="width:100%;height:auto;display:block"></div>
+<figcaption style="padding:14px 18px;border-top:1px solid rgba(255,255,255,.07);font-size:13px;line-height:1.55;color:#8a8c90">Two interface modes on the left, the headless harness on the right, the evals plane underneath.</figcaption>
+</figure>
+</div>
+</div>
 </section>
 
-<section id="skills">
-  <div class="wrap">
-    <h2><span class="hash">##</span>You'll Walk Away Knowing How To</h2>
-    <ul class="checks">
-      <li>Design a coding agent harness from scratch</li>
-      <li>Implement a headless coding agent loop</li>
-      <li>Attach the headless harness to multiple modes: TUI and remote</li>
-      <li>Add a runtime for durable execution, human-in-the-loop and replays when running parallel agents</li>
-      <li>Implement guardrails and safety nets for the agent's behavior by adding a permission layer and local &amp; remote sandboxing</li>
-      <li>Build essential context engineering techniques: memory, compaction, skills</li>
-      <li>Hook up an LSP server for faster feedback loops</li>
-      <li>Implement an agents catalog: build, plan, code reviewer and exploration agents</li>
-      <li>Spawn parallel subagents via fan-out strategies</li>
-      <li>Add observability</li>
-      <li>Design an eval harness for benchmarking the agent and checking for regressions</li>
-      <li>Deploy and run swarms of agents</li>
-    </ul>
+<section id="curriculum" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Course outline</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">03</span></div>
+<div style="display:flex;flex-wrap:wrap;align-items:end;justify-content:space-between;gap:20px;margin:12px 0 clamp(24px,3.6vh,38px)">
+<div style="min-width:0">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;text-wrap:pretty">Eight Lessons. Four Videos.</h2>
+<p style="font-size:15px;line-height:1.65;color:var(--fg-2);margin:14px 0 0;white-space:nowrap">From designing the harness to deploying a swarm of remote agents.</p>
+</div>
+<div style="display:flex;gap:8px">
+<span style="display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:11.5px;font-weight:700;color:#fff;background:var(--primary);border-radius:var(--radius-pill);padding:6px 13px">2 live</span>
+<span style="display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:11.5px;color:var(--fg-3);border:1px dashed var(--border-strong);border-radius:var(--radius-pill);padding:6px 13px">6 coming</span>
+</div>
+</div>
 
-    <figure>
-      <img src="assets/tui-plan-mode-todo.png" alt="decode in plan mode breaking the Snake demo into a task list with the todo tool" style="max-width:860px">
-      <figcaption>Plan mode, live: the agent breaks the Snake demo into a task list with the <code>todo</code> tool — <code>[x]</code> done, <code>[~]</code> in progress.</figcaption>
-    </figure>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(14px,1.8vw,20px)">
 
-    <h3>Tech Stack</h3>
-    <p>The code is written in Python, with the following frameworks and libraries:</p>
-    <ul class="checks">
-      <li><b>Agent Framework:</b> <a href="https://ai.pydantic.dev" target="_blank" rel="noopener">Pydantic AI</a></li>
-      <li><b>LLM Providers:</b> <a href="https://modal.com/docs/guide/endpoints?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal</a> (open weights you serve yourself via SGLang), OpenRouter (open weights as a service), or Gemini (proprietary).</li>
-      <li><b>Durable Runtime &amp; Replays:</b> <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&utm_medium=referral&utm_campaign=coding-agent-course&utm_content=brand" target="_blank" rel="noopener">Kitaru</a></li>
-      <li><b>Observability &amp; Evals:</b> <a href="https://www.comet.com/site/?utm_source=workshop&utm_medium=partner&utm_campaign=paul&utm_content=coding_agent_course" target="_blank" rel="noopener">Opik</a></li>
-      <li><b>Sandboxing:</b> local Docker &amp; remote <a href="https://modal.com/docs/guide/sandboxes?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal sandboxes</a></li>
-      <li><b>Deploying:</b> GCP &amp; Modal</li>
-    </ul>
-    <p style="margin-top:1rem;">Otherwise, we build all the functionality from scratch, to teach you the foundations that last, not frameworks that abstract away the hard parts.</p>
-  </div>
+<article class="x5" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-md);display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<a href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener" style="display:block"><img src="assets/architecture.png" alt="Lesson 1 — the harness architecture" style="width:100%;background:var(--surface-2)"></a>
+<div style="padding:22px 24px;display:flex;flex-direction:column;flex:1">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--primary)">Lesson 1</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#fff;background:var(--primary);border-radius:var(--radius-pill);padding:3px 9px">live</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 1 coming soon</span>
+</div>
+<h3 style="font-size:19px;font-weight:700;line-height:1.28;letter-spacing:-.012em;color:var(--fg);margin:12px 0 8px;text-wrap:pretty">Harness Architecture</h3>
+<p style="font-size:14px;line-height:1.6;color:var(--fg-2);margin:0 0 18px;flex:1">Designing the harness around the model, from the agent loop to a remote swarm.</p>
+<div style="display:flex;flex-wrap:wrap;gap:8px 18px;font-family:var(--font-mono);font-size:12.5px">
+<a href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;color:var(--primary);font-weight:700;text-decoration:none">read lesson <i data-lucide="arrow-right" style="width:13px;height:13px"></i></a>
+<a class="x6" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/01_install_and_usage.md" target="_blank" rel="noopener" style="color:var(--fg-3);text-decoration:none">install_and_usage.md</a>
+</div>
+</div>
+</article>
+
+<article class="x5" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-md);display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<a href="https://www.decodingai.com/p/the-coding-agent-loop" target="_blank" rel="noopener" style="display:block"><img src="assets/architecture_lesson_2.png" alt="Lesson 2 — the bare-bones coding agent loop" style="width:100%;background:var(--surface-2)"></a>
+<div style="padding:22px 24px;display:flex;flex-direction:column;flex:1">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--primary)">Lesson 2</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#fff;background:var(--primary);border-radius:var(--radius-pill);padding:3px 9px">live</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 2 coming soon</span>
+</div>
+<h3 style="font-size:19px;font-weight:700;line-height:1.28;letter-spacing:-.012em;color:var(--fg);margin:12px 0 8px;text-wrap:pretty">The Bare-Bones Coding Agent Loop</h3>
+<p style="font-size:14px;line-height:1.6;color:var(--fg-2);margin:0 0 18px;flex:1">One agent loop, 9 tools, and a terminal you can steer.</p>
+<div style="display:flex;flex-wrap:wrap;gap:8px 18px;font-family:var(--font-mono);font-size:12.5px">
+<a href="https://www.decodingai.com/p/the-coding-agent-loop" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:6px;color:var(--primary);font-weight:700;text-decoration:none">read lesson <i data-lucide="arrow-right" style="width:13px;height:13px"></i></a>
+<a class="x6" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/01_install_and_usage.md" target="_blank" rel="noopener" style="color:var(--fg-3);text-decoration:none">install_and_usage.md</a>
+<a class="x6" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/02_modal_endpoints.md" target="_blank" rel="noopener" style="color:var(--fg-3);text-decoration:none">modal_models.md</a>
+</div>
+</div>
+</article>
+</div>
+
+<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:clamp(14px,1.8vw,20px);margin:clamp(14px,1.8vw,20px) 0 0">
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 3</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 2</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">The Runtime: Durable Execution, HITL &amp; Replays</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px"><span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">kill -9</span> a headless run, resume it from checkpoints, replay it with the model swapped.</p>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/03_runtime.md" target="_blank" rel="noopener" style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-3);text-decoration:none">runtime.md</a>
+</article>
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 4</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 3</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">Containing the Agent: Permissions &amp; Sandbox</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px">Four permission modes, then Docker and Modal sandboxes — nothing executes on your machine.</p>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/04_sandboxing.md" target="_blank" rel="noopener" style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-3);text-decoration:none">sandboxing.md</a>
+</article>
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 5</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 3</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">Context Engineering for Coding Agents</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px">Memory, compaction, skills, and LSP — the context window treated as a budget.</p>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/01_install_and_usage.md" target="_blank" rel="noopener" style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-3);text-decoration:none">install_and_usage.md</a>
+</article>
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 6</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 3</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">Agents Catalog, Subagents &amp; Parallel Fan-out</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px">One call fans out N parallel subagents, each with a budget and a report contract.</p>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/01_install_and_usage.md" target="_blank" rel="noopener" style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-3);text-decoration:none">install_and_usage.md</a>
+</article>
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 7</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">video 4</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">Does It Work? Benchmarks, Regression &amp; Online Evals</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px">Benchmarks, regression probes, and online evals: does it work, still work, keep working?</p>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/05_evals.md" target="_blank" rel="noopener" style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-3);text-decoration:none">evals.md</a>
+</article>
+
+<article class="x7" style="background:transparent;border:1px dashed var(--border-strong);border-radius:var(--radius-lg);padding:22px 24px;transition:background .2s,border-color .2s">
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:9px">
+<span style="font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--fg-3)">Lesson 8</span>
+<span style="font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--fg-3);border:1px solid var(--border-strong);border-radius:var(--radius-pill);padding:3px 9px">soon</span>
+<span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-3)">no video</span>
+</div>
+<h3 style="font-size:17px;font-weight:700;line-height:1.3;letter-spacing:-.012em;color:var(--fg-2);margin:12px 0 8px;text-wrap:pretty">Running Swarms of Remote Agents</h3>
+<p style="font-size:13.5px;line-height:1.6;color:var(--fg-3);margin:0 0 16px">Deploy to GCP + Modal and build the same feature 5–10× in parallel — judged, winner merged.</p>
+<div style="display:flex;flex-wrap:wrap;gap:8px 16px;font-family:var(--font-mono);font-size:12.5px">
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/06_credentials.md" target="_blank" rel="noopener" style="color:var(--fg-3);text-decoration:none">credentials.md</a>
+<a class="x8" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/07_infra.md" target="_blank" rel="noopener" style="color:var(--fg-3);text-decoration:none">infra.md</a>
+</div>
+</article>
+</div>
+</div>
 </section>
 
-<section id="why">
-  <div class="wrap">
-    <h2><span class="hash">##</span>The code tells you <i>what</i>. The lessons tell you <i>why</i>.</h2>
-    <p>For the full experience, go through the articles and videos that cover what the code can't. <b>The why behind every decision.</b></p>
-    <p>
-      Why we have a headless harness and two interface modes: TUI + Remote.<br>
-      What the essential components of a coding agent are, and what is optional.<br>
-      Why we plugged in 9 tools, no more, no less.<br>
-      Why we need a durable runtime and replays.<br>
-      What guardrails are actually useful.<br>
-      Why compaction fires at ~80% of the window instead of at the limit.<br>
-      Why you need benchmarks, regression tests and online evals.
-    </p>
-  </div>
+<section id="why" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Why the lessons</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">04</span></div>
+<div style="display:flex;flex-wrap:wrap;align-items:end;justify-content:space-between;gap:14px 40px;margin:clamp(18px,2.6vh,26px) 0 0">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;text-wrap:pretty">The Code Tells You <i><span style="font-style: normal;">What</span></i>. The Lessons Tell You <i><span style="font-style: normal;">Why</span></i>.</h2>
+<p style="font-size:15px;line-height:1.6;color:var(--fg-2);margin:0;white-space:nowrap">The articles and videos cover what the code can't. <b style="color:var(--fg)">The why behind every decision.</b></p>
+</div>
+
+<div style="max-width:62ch;margin:clamp(22px,3vh,32px) 0 0;border-top:1px solid var(--border-strong)">
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">01</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">Why</span></b> a headless harness with two interface modes, TUI and Remote.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">02</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">What</span></b> the essential components of a coding agent are, and what is optional.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">03</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">Why</span></b> we plugged in 9 tools, no more, no less.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">04</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">Why</span></b> we need a durable runtime and replays.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">05</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">What</span></b> guardrails are actually useful.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">06</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">Why</span></b> compaction fires at ~80% of the window instead of at the limit.</p></div>
+<div style="display:flex;align-items:baseline;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)"><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--primary);flex:none">07</span><p style="font-size:14.5px;line-height:1.5;color:var(--fg-2);margin:0"><b style="color:var(--fg)"><span style="font-weight: normal;">Why</span></b> you need benchmarks, regression tests and online evals.</p></div>
+</div>
+</div>
 </section>
 
-<section id="outline">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Course Outline</h2>
-    <div class="cards">
-      <div class="card">
-        <span class="num">Lesson 1</span> <span class="live">● live</span> <span class="soon">· video 1 coming soon</span>
-        <h4>Building a Coding Agent From Scratch: Harness Architecture</h4>
-        <figure>
-          <a href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener"><img src="assets/architecture.png" alt="Lesson 1 — the harness architecture"></a>
-        </figure>
-        <p>Designing the harness around the model, from the agent loop to a remote swarm.</p>
-        <div class="links">
-          <a href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener">read lesson →</a>
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/install_and_usage.md" target="_blank" rel="noopener">install_and_usage.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 2</span> <span class="live">● live</span> <span class="soon">· video 2 coming soon</span>
-        <h4>The Bare-Bones Coding Agent Loop</h4>
-        <figure>
-          <a href="https://www.decodingai.com/p/the-coding-agent-loop" target="_blank" rel="noopener"><img src="assets/architecture_lesson_2.png" alt="Lesson 2 — the bare-bones coding agent loop"></a>
-        </figure>
-        <p>One agent loop, 9 tools, and a terminal you can steer.</p>
-        <div class="links">
-          <a href="https://www.decodingai.com/p/the-coding-agent-loop" target="_blank" rel="noopener">read lesson →</a>
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/install_and_usage.md" target="_blank" rel="noopener">install_and_usage.md</a>
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/modal_models.md" target="_blank" rel="noopener">modal_models.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 3</span> <span class="soon">○ coming soon · video 2</span>
-        <h4>The Runtime: Durable Execution, HITL &amp; Replays (The Headless Mode)</h4>
-        <p><code>kill -9</code> a headless run, resume it from checkpoints, replay it with the model swapped.</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/runtime.md" target="_blank" rel="noopener">runtime.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 4</span> <span class="soon">○ coming soon · video 3</span>
-        <h4>Containing the Agent: Permissions &amp; Sandbox</h4>
-        <p>Four permission modes, then Docker and Modal sandboxes — nothing executes on your machine.</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/sandboxing.md" target="_blank" rel="noopener">sandboxing.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 5</span> <span class="soon">○ coming soon · video 3</span>
-        <h4>Context Engineering for Coding Agents</h4>
-        <p>Memory, compaction, skills, and LSP — the context window treated as a budget.</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/install_and_usage.md" target="_blank" rel="noopener">install_and_usage.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 6</span> <span class="soon">○ coming soon · video 3</span>
-        <h4>Agents Catalog, Subagents &amp; Parallel Fan-out</h4>
-        <p>One call fans out N parallel subagents, each with a budget and a report contract.</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/install_and_usage.md" target="_blank" rel="noopener">install_and_usage.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 7</span> <span class="soon">○ coming soon · video 4</span>
-        <h4>Does It Work? Benchmarks, Regression &amp; Online AI Evals</h4>
-        <p>Benchmarks, regression probes, and online evals: does it work, still work, keep working?</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/evals.md" target="_blank" rel="noopener">evals.md</a>
-        </div>
-      </div>
-      <div class="card">
-        <span class="num">Lesson 8</span> <span class="soon">○ coming soon · no video</span>
-        <h4>Running Swarms of Remote Agents</h4>
-        <p>Deploy to GCP + Modal and build the same feature 5–10× in parallel — judged, winner merged.</p>
-        <div class="links">
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/credentials.md" target="_blank" rel="noopener">credentials.md</a>
-          <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/infra.md" target="_blank" rel="noopener">infra.md</a>
-        </div>
-      </div>
-    </div>
-  </div>
+<section id="see-it-work" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">See it work</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">05</span></div>
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:12px 0 0;text-wrap:pretty">Six Demos. One Keystroke Away.</h2>
+<p style="font-size:15px;line-height:1.65;color:var(--fg-2);margin:14px 0 0;white-space:nowrap">Demo skills live under <span style="font-family:var(--font-mono);font-size:14px;color:var(--fg);background:var(--surface-2);border:1px solid var(--border);border-radius:4px;padding:2px 6px">.decode/skills/</span>. Type <span style="font-family:var(--font-mono);font-size:14px;color:var(--fg);background:var(--surface-2);border:1px solid var(--border);border-radius:4px;padding:2px 6px">/demo-</span> in the TUI, pick one, and watch the harness do real work.</p>
+
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(14px,1.8vw,20px);margin:clamp(24px,3.6vh,38px) 0 0">
+<figure style="margin:0;grid-column:1 / -1;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden">
+<img src="assets/demo-skills.png" alt="The demo skills listed inside the decode TUI after typing /demo-" style="width:100%">
+<figcaption style="flex:1;padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Implement the Skills Standard</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)">Type <span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">/demo-</span> and the six demos are one keystroke away.</span></figcaption>
+</figure>
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#242835"><img src="assets/demo-snake-game.png" alt="A playable Snake game built by decode" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Capable of Creating Games</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)"><span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">/demo-1-terminal-arcade</span> — one prompt, a playable Snake game</span></figcaption>
+</figure>
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#0c1117"><img src="assets/demo-repo-pulse.png" alt="Live GitHub repo data rendered as a web dashboard" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Fetching Data &amp; Creating Dashboards</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)"><span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">/demo-3-repo-pulse</span> — live GitHub API data rendered as a dashboard</span></figcaption>
+</figure>
+<figure style="margin:0;grid-column:1 / -1;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden">
+<img src="assets/demo-knowledge-graph.png" alt="An interactive knowledge graph scraped from web articles" style="width:100%">
+<figcaption style="flex:1;padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Extracting Ontologies &amp; Rendering Graphs</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)"><span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">/demo-6-article-kg</span> — web articles scraped into an interactive knowledge graph</span></figcaption>
+</figure>
+</div>
+
+<div style="position:relative;overflow:hidden;display:flex;align-items:center;gap:clamp(16px,2.4vw,30px);margin:clamp(30px,4.4vh,50px) 0 0;padding:clamp(16px,2.2vh,24px) 0"><span style="position:absolute;top:0;bottom:0;left:50%;transform:translateX(-50%);width:min(900px,96%);pointer-events:none;background:linear-gradient(90deg,rgba(127,238,100,.3) 12%,rgba(227,13,62,.38) 50%,rgba(220,105,46,.35) 88%);filter:blur(22px);-webkit-mask-image:radial-gradient(closest-side ellipse at 50% 50%,#000 30%,transparent 100%);mask-image:radial-gradient(closest-side ellipse at 50% 50%,#000 30%,transparent 100%)"></span><span style="flex:1;height:1px;background:linear-gradient(90deg,transparent,var(--border-strong))"></span>
+<h3 style="position:relative;font-size:clamp(19px,2.2vw,26px);font-weight:800;line-height:1.15;letter-spacing:-.02em;color:var(--fg);margin:0;flex:none;text-align:center">And the infra that powers the agents.</h3>
+<span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span></div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(14px,1.8vw,20px);margin:clamp(18px,2.6vh,26px) 0 0">
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#262624"><img src="assets/kitaru-replay.png" alt="A durable run recorded step by step in Kitaru" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Durability &amp; Replay for AI Agents</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)">Every run recorded step by step in <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&amp;utm_medium=referral&amp;utm_campaign=coding-agent-course&amp;utm_content=brand" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Kitaru</a> — kill it, resume it, replay it with the model swapped</span></figcaption>
+</figure>
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#181818"><img src="assets/modal-sandboxes.png" alt="Live Modal sandboxes executing the agent's tools" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Remote Sandboxing</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)">The agent's <span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">bash</span> runs in disposable <a href="https://modal.com/docs/guide/sandboxes?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Modal sandboxes</a></span></figcaption>
+</figure>
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#181818"><img src="assets/modal-open-model.png" alt="A self-served open model endpoint on Modal" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Powered by Open Source Models</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)">Your own Qwen3.6-35B served on an H200 via a <a href="https://modal.com/docs/guide/endpoints?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Modal endpoint</a></span></figcaption>
+</figure>
+<figure class="x5" style="margin:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1),box-shadow .2s">
+<div style="flex:1;background:#ffffff"><img src="assets/opik-threads.png" alt="Sessions traced in Opik with secrets scrubbed" style="width:100%;display:block"></div>
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border)"><b style="display:block;font-size:14.5px;color:var(--fg);margin-bottom:4px">Adding AI Evals &amp; Observability</b><span style="font-size:13.5px;line-height:1.55;color:var(--fg-3)">Every session traced in <a href="https://www.comet.com/site/?utm_source=workshop&amp;utm_medium=partner&amp;utm_campaign=paul&amp;utm_content=coding_agent_course" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Opik</a></span></figcaption>
+</figure>
+</div>
+</div>
 </section>
 
-<section id="who">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Who Should Join?</h2>
-    <p><b>For: engineers who learn by building.</b> You finish with a working coding agent that teaches you harness engineering patterns to steal for your own agentic applications.</p>
-    <p>Best for <b>ML/AI engineers</b> who want to level up their craft and for <b>software engineers and data scientists</b> who want to transition into building agentic systems from scratch.</p>
-  </div>
+<section id="skills" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Outcomes</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">06</span></div>
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:12px 0 0;text-wrap:pretty">You'll Walk Away Knowing How To</h2>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:0 clamp(24px,3.4vw,48px);margin:clamp(22px,3.4vh,34px) 0 0">
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Design a coding agent harness from scratch</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Implement a headless coding agent loop</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Attach the headless harness to multiple modes: TUI and remote</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Add a runtime for durable execution, human-in-the-loop and replays</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Implement guardrails: a permission layer plus local &amp; remote sandboxing</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Build essential context engineering techniques: memory, compaction, skills</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Hook up an LSP server for faster feedback loops</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Implement an agents catalog: build, plan, code reviewer and exploration agents</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Spawn parallel subagents via fan-out strategies</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Add observability</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Design an eval harness for benchmarking and catching regressions</span></div>
+<div style="display:flex;gap:13px;padding:13px 0;border-bottom:1px solid var(--border)"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:9px;flex:none"></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Deploy and run swarms of agents</span></div>
+</div>
+
+<figure style="margin:clamp(26px,4vh,42px) 0 0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden">
+<img src="assets/tui-plan-mode-todo.png" alt="decode in plan mode breaking the Snake demo into a task list with the todo tool" style="width:100%">
+<figcaption style="padding:16px 20px;border-top:1px solid var(--border);font-size:13.5px;line-height:1.55;color:var(--fg-3)">Plan mode, live: the agent breaks the Snake demo into a task list with the <span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">todo</span> tool — <span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">[x]</span> done, <span style="font-family:var(--font-mono);font-size:12.5px;color:var(--fg-2)">[~]</span> in progress.</figcaption>
+</figure>
+
+<div style="display:flex;align-items:center;gap:clamp(16px,2.4vw,30px);margin:clamp(30px,4.4vh,50px) 0 0;padding:clamp(16px,2.2vh,24px) 0 0"><span style="flex:1;height:1px;background:linear-gradient(90deg,transparent,var(--border-strong))"></span>
+<h3 style="font-size:clamp(19px,2.2vw,26px);font-weight:800;line-height:1.15;letter-spacing:-.02em;color:var(--fg);margin:0;flex:none;text-align:center">Tech Stack</h3>
+<span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span></div>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:12px 0 0;text-align:center">The code is written in Python, with the following frameworks and libraries:</p>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:clamp(12px,1.6vw,18px);margin:clamp(18px,2.6vh,26px) 0 0">
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">Agent framework</div>
+<div style="font-size:15px;line-height:1.6;color:var(--fg-2);margin:10px 0 0"><a href="https://ai.pydantic.dev" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Pydantic AI</a></div>
+</div>
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">LLM providers</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);margin:10px 0 0"><a href="https://modal.com/docs/guide/endpoints?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Modal</a> (open weights you serve yourself via SGLang), OpenRouter (open weights as a service), or Gemini (proprietary)</div>
+</div>
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">Durable runtime &amp; replays</div>
+<div style="font-size:15px;line-height:1.6;color:var(--fg-2);margin:10px 0 0"><a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&amp;utm_medium=referral&amp;utm_campaign=coding-agent-course&amp;utm_content=brand" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Kitaru</a></div>
+</div>
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">Observability &amp; evals</div>
+<div style="font-size:15px;line-height:1.6;color:var(--fg-2);margin:10px 0 0"><a href="https://www.comet.com/site/?utm_source=workshop&amp;utm_medium=partner&amp;utm_campaign=paul&amp;utm_content=coding_agent_course" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Opik</a></div>
+</div>
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">Sandboxing</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);margin:10px 0 0">Local Docker &amp; remote <a href="https://modal.com/docs/guide/sandboxes?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Modal sandboxes</a></div>
+</div>
+<div class="x9" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:20px 22px;transition:border-color .2s,transform .18s cubic-bezier(.2,.8,.2,1)">
+<div style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">Deploying</div>
+<div style="font-size:15px;line-height:1.6;color:var(--fg-2);margin:10px 0 0">GCP &amp; Modal</div>
+</div>
+</div>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:clamp(16px,2.4vh,22px) 0 0;white-space:nowrap;text-align:center">Otherwise, we build everything from scratch, to teach foundations that last, not frameworks that hide the hard parts.</p>
+</div>
 </section>
 
-<section id="prerequisites">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Prerequisites</h2>
-    <div class="tbl-wrap">
-      <table class="tbl">
-        <tr><th>Category</th><th>Requirements</th></tr>
-        <tr><td><b>Skills</b></td><td>Python (Intermediate)<br>LLMs &amp; agents (Beginner)</td></tr>
-        <tr><td><b>Hardware</b></td><td>Any modern machine will do. No GPU required, as we run all the LLMs in the cloud.</td></tr>
-        <tr><td><b>Level</b></td><td>Intermediate (but with a little sweat and patience, anyone can do it)</td></tr>
-        <tr><td><b>Time</b></td><td>~4–8 hours for the whole course — 4 if you read and watch, 6–8 if you run everything.</td></tr>
-      </table>
-    </div>
-  </div>
+<section id="who" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto;display:grid;grid-template-columns:1.25fr .75fr;gap:clamp(18px,2.6vh,26px) clamp(28px,4vw,56px);align-items:start">
+<div style="grid-column:1/-1;display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Who should join</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">07</span></div>
+<div style="min-width:0">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;text-wrap:pretty">Engineers Who Learn by Building.</h2>
+<p style="font-size:clamp(17px,1.55vw,20px);line-height:1.6;color:var(--fg-2);margin:20px 0 0;text-wrap:pretty">You finish with a working coding agent that teaches you harness engineering patterns to steal for your own agentic applications.</p>
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent);margin:clamp(22px,3vh,30px) 0 0">Best for</div>
+<div style="display:grid;gap:12px;margin:12px 0 0">
+<div style="display:flex;gap:13px"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:8px;flex:none"></span><span style="font-size:15.5px;line-height:1.55;color:var(--fg-2)"><b style="color:var(--fg)">ML/AI Engineers</b> levelling up their craft</span></div>
+<div style="display:flex;gap:13px"><span style="width:6px;height:6px;border-radius:50%;background:var(--gradient-warm);margin-top:8px;flex:none"></span><span style="font-size:15.5px;line-height:1.55;color:var(--fg-2)"><b style="color:var(--fg)">Software Engineers and Data Scientists</b> moving into agentic systems</span></div>
+</div>
+</div>
+<div id="prerequisites" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:8px clamp(20px,2.4vw,28px)">
+<div style="display:grid;grid-template-columns:auto 1fr;gap:0 clamp(18px,2.2vw,28px)">
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);padding:16px 0;border-bottom:1px solid var(--border)">Skills</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);padding:16px 0;border-bottom:1px solid var(--border)">Python (Intermediate), LLMs &amp; agents (Beginner)</div>
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);padding:16px 0;border-bottom:1px solid var(--border)">Hardware</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);padding:16px 0;border-bottom:1px solid var(--border)">Any modern machine will do. No GPU required, as we run all the LLMs in the cloud.</div>
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);padding:16px 0;border-bottom:1px solid var(--border)">Level</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);padding:16px 0;border-bottom:1px solid var(--border)">Intermediate (but with a little sweat and patience, anyone can do it)</div>
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);padding:16px 0">Time</div>
+<div style="font-size:14.5px;line-height:1.6;color:var(--fg-2);padding:16px 0">~4–8 hours for the whole course — 4 if you read and watch, 6–8 if you run everything.</div>
+</div>
+</div>
+</div>
 </section>
 
-<section id="cost">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Cost Structure</h2>
-    <p>Running the code costs <b>$0</b> if you stick to free tiers:</p>
-    <div class="tbl-wrap">
-      <table class="tbl">
-        <tr><th>Service</th><th>Cost</th></tr>
-        <tr><td>Gemini API (default provider — easy setup, but limited API requests)</td><td>free tier (<a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">Google AI Studio</a>)</td></tr>
-        <tr><td><a href="https://modal.com?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal</a> (recommended provider + remote sandbox)</td><td>$30 free credits — enough to run the course</td></tr>
-        <tr><td>OpenRouter (alternative provider)</td><td>$0 on <code>:free</code> models (optional $10 credit raises the daily cap)</td></tr>
-        <tr><td><a href="https://www.comet.com/site/?utm_source=workshop&utm_medium=partner&utm_campaign=paul&utm_content=coding_agent_course" target="_blank" rel="noopener">Opik</a> (tracing + evals)</td><td>free tier</td></tr>
-        <tr><td><a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&utm_medium=referral&utm_campaign=coding-agent-course&utm_content=brand" target="_blank" rel="noopener">Kitaru</a> (durable runtime)</td><td>free, runs locally offline</td></tr>
-        <tr><td>GCP — deploy the agent to run remotely <i>(optional)</i></td><td>~$16/month while it's up; new GCP accounts get $300 in credits — see <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/infra.md" target="_blank" rel="noopener">infra.md</a></td></tr>
-      </table>
-    </div>
-    <p style="margin-top:1rem;"><b>Reading-only? Everything's free!</b></p>
-  </div>
+<section id="cost" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Cost structure</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">08</span></div>
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:12px 0 0;text-wrap:pretty">Running It Costs <span class="text-gradient">$0</span>.</h2>
+<p style="font-size:15px;line-height:1.65;color:var(--fg-2);margin:14px 0 0;max-width:60ch">If you stick to free tiers. Reading only? Everything's free, full stop.</p>
+<div style="display:grid;margin:clamp(22px,3.4vh,34px) 0 0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden">
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:14px clamp(20px,2.4vw,28px);background:var(--surface-3);border-bottom:1px solid var(--border-strong);font-family:var(--font-mono);font-size:10.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--fg-2)"><span>Service</span><span>Cost</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);border-bottom:1px solid var(--border);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">Gemini API <span style="color:var(--fg-3)">(default provider — easy setup, but limited API requests)</span></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg)">free tier (<a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Google AI Studio</a>)</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);border-bottom:1px solid var(--border);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)"><a href="https://modal.com/?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Modal</a> <span style="color:var(--fg-3)">(recommended provider + remote sandbox)</span></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg)">$30 free credits — enough to run the course</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);border-bottom:1px solid var(--border);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">OpenRouter <span style="color:var(--fg-3)">(alternative provider)</span></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg)">$0 on <span style="font-family:var(--font-mono);font-size:13.5px">:free</span> models (optional $10 credit raises the daily cap)</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);border-bottom:1px solid var(--border);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)"><a href="https://www.comet.com/site/?utm_source=workshop&amp;utm_medium=partner&amp;utm_campaign=paul&amp;utm_content=coding_agent_course" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Opik</a> <span style="color:var(--fg-3)">(tracing + evals)</span></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg)">free tier</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);border-bottom:1px solid var(--border);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)"><a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&amp;utm_medium=referral&amp;utm_campaign=coding-agent-course&amp;utm_content=brand" target="_blank" rel="noopener" style="color:var(--primary);font-weight:700;text-decoration:none">Kitaru</a> <span style="color:var(--fg-3)">(durable runtime)</span></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg)">free, runs locally offline</span></div>
+<div style="display:grid;grid-template-columns:1.35fr 1fr;gap:clamp(16px,2vw,28px);padding:16px clamp(20px,2.4vw,28px);align-items:baseline"><span style="font-size:14.5px;line-height:1.55;color:var(--fg-2)">GCP — deploy the agent to run remotely <i style="color:var(--fg-3)">(optional)</i></span><span style="font-size:14.5px;line-height:1.55;color:var(--fg);white-space:nowrap">~$16/month while up; new accounts get $300 in credits. <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/07_infra.md" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">infra.md</a></span></div>
+</div>
+</div>
 </section>
 
-<section id="how-it-works">
-  <div class="wrap">
-    <h2><span class="hash">##</span>How It Works</h2>
-    <p>As an open-source course, everything is self-paced, based on this repository, plus the attached lessons that walk you through the code. No paywall. No platform.</p>
-    <p>Read the lessons on the <a href="https://www.decodingai.com" target="_blank" rel="noopener">Decoding AI Magazine</a>, watch the videos from the <a href="https://www.youtube.com/@itsdecodingai" target="_blank" rel="noopener">Decoding AI Channel</a>, run the code on your own machine, break it, fix it, and learn from the process.</p>
-  </div>
-</section>
-
-<section id="structure">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Project Structure</h2>
-    <p>One Python package; each module maps to one part of the architecture:</p>
-<pre class="code">.
+<section id="structure" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:grid;grid-template-columns:.95fr 1.05fr;gap:clamp(18px,2.6vh,26px) clamp(24px,4vw,56px);align-items:start">
+<div style="grid-column:1/-1;display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Project structure</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">09</span></div>
+<div style="min-width:0">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;white-space:nowrap">One Module Per Concept.</h2>
+<p style="font-size:16.5px;line-height:1.72;color:var(--fg-2);margin:18px 0 0;text-wrap:pretty">One Python package; each module maps to one part of the architecture.<br></p>
+<div style="margin:clamp(26px,3.6vh,36px) 0 0">
+<div style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)">How it works</div>
+<p style="font-size:15.5px;line-height:1.72;color:var(--fg-2);margin:12px 0 0;text-wrap:pretty">Self-paced, based on this repository plus the lessons that walk you through the code. No paywall. No platform.</p>
+<p style="font-size:15.5px;line-height:1.72;color:var(--fg-2);margin:14px 0 0;text-wrap:pretty">Read the lessons on the <a href="https://www.decodingai.com" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Decoding AI Magazine</a>, watch the videos on the <a href="https://www.youtube.com/@itsdecodingai" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Decoding AI Channel</a>, run the code on your own machine, break it, fix it, and learn from the process.</p>
+</div>
+</div>
+<div style="background:var(--black-3);border:1px solid var(--border);border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-md)">
+<div style="display:flex;align-items:center;gap:7px;padding:10px 14px;background:rgba(255,255,255,.04);border-bottom:1px solid rgba(255,255,255,.07)">
+<span style="width:9px;height:9px;border-radius:50%;background:#ff5f57;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#febc2e;flex:none"></span>
+<span style="width:9px;height:9px;border-radius:50%;background:#28c840;flex:none"></span>
+<span style="font-family:var(--font-mono);font-size:11px;color:#8a8c90;margin-left:6px">tree -L 2</span>
+</div>
+<pre style="margin:0;padding:24px 26px;overflow-x:auto;font-family:var(--font-mono);font-size:12px;line-height:1.85;color:#f3f3f4">.
 ├── docs/
-│   ├── adr/                  <span class="c"># Architecture Decision Records — the "why" of every choice</span>
-│   ├── glossary.md           <span class="c"># one canonical name per concept</span>
-│   └── evals.md              <span class="c"># the four-track eval suite, mapped</span>
-├── evals/                    <span class="c"># benchmark + regression probes + demo skills</span>
-├── tests/{unit,integration}/ <span class="c"># mirrors src/ 1:1; milestone capstones prove each milestone</span>
+│   ├── adr/                  <span style="color:#6b6c6f"># Architecture Decision Records — the "why" of every choice</span>
+│   ├── glossary.md           <span style="color:#6b6c6f"># one canonical name per concept</span>
+│   └── evals.md              <span style="color:#6b6c6f"># the four-track eval suite, mapped</span>
+├── evals/                    <span style="color:#6b6c6f"># benchmark + regression probes + demo skills</span>
+├── tests/{unit,integration}/ <span style="color:#6b6c6f"># mirrors src/ 1:1; milestone capstones prove each milestone</span>
 └── src/decode/
-    ├── cli.py                <span class="c"># Click entrypoint → launches the TUI</span>
-    ├── tui/                  <span class="c"># input: prompt_toolkit · output: Rich</span>
-    ├── harness/              <span class="c"># message queue + priority gate around the loop</span>
-    ├── agent/                <span class="c"># the Pydantic-AI ReAct loop (LLM ⇄ tools)</span>
-    ├── agents/               <span class="c"># agents catalog: Build / Plan / Code-Reviewer + Explore subagent</span>
-    ├── tools/                <span class="c"># file I/O, bash, web, todo, skills dispatch, LSP, ask_user</span>
-    ├── permissions/          <span class="c"># allow/ask/deny · modes · settings.json</span>
-    ├── sandbox/              <span class="c"># bash + file tools seam: none (host) / docker / modal</span>
-    ├── services/lsp/         <span class="c"># hand-rolled stdio LSP client (ty)</span>
-    ├── runtime/              <span class="c"># Kitaru durable flow: decode run / replay / HITL</span>
-    ├── context/              <span class="c"># compaction + conversation log (JSONL)</span>
-    ├── memory/               <span class="c"># AGENTS.md / MEMORY.md loading + write-back</span>
-    ├── observability/        <span class="c"># Opik tracing</span>
-    └── config/, entities/    <span class="c"># settings singleton · shared models</span></pre>
-  </div>
+    ├── cli.py                <span style="color:#6b6c6f"># Click entrypoint → launches the TUI</span>
+    ├── tui/                  <span style="color:#6b6c6f"># input: prompt_toolkit · output: Rich</span>
+    ├── harness/              <span style="color:#6b6c6f"># message queue + priority gate around the loop</span>
+    ├── agent/                <span style="color:#6b6c6f"># the Pydantic-AI ReAct loop (LLM ⇄ tools)</span>
+    ├── agents/               <span style="color:#6b6c6f"># agents catalog: Build / Plan / Code-Reviewer + Explore subagent</span>
+    ├── tools/                <span style="color:#6b6c6f"># file I/O, bash, web, todo, skills dispatch, LSP, ask_user</span>
+    ├── permissions/          <span style="color:#6b6c6f"># allow/ask/deny · modes · settings.json</span>
+    ├── sandbox/              <span style="color:#6b6c6f"># bash + file tools seam: none (host) / docker / modal</span>
+    ├── services/lsp/         <span style="color:#6b6c6f"># hand-rolled stdio LSP client (ty)</span>
+    ├── runtime/              <span style="color:#6b6c6f"># Kitaru durable flow: decode run / replay / HITL</span>
+    ├── context/              <span style="color:#6b6c6f"># compaction + conversation log (JSONL)</span>
+    ├── memory/               <span style="color:#6b6c6f"># AGENTS.md / MEMORY.md loading + write-back</span>
+    ├── observability/        <span style="color:#6b6c6f"># Opik tracing</span>
+    └── config/, entities/    <span style="color:#6b6c6f"># settings singleton · shared models</span></pre>
+</div>
+</div>
+</div>
 </section>
 
-<section id="running">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Running the Code</h2>
-    <p>Everything lives under <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/tree/main/running_the_code" target="_blank" rel="noopener"><code>running_the_code/</code></a>. One core guide, plus one focused guide per side quest:</p>
-    <div class="tbl-wrap">
-      <table class="tbl">
-        <tr><th>Guide</th><th>What's inside</th></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/install_and_usage.md" target="_blank" rel="noopener">install_and_usage.md</a></td><td>Start here</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/troubleshooting.md" target="_blank" rel="noopener">troubleshooting.md</a></td><td>Every known failure, and its fix</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/modal_models.md" target="_blank" rel="noopener">modal_models.md</a></td><td>Serving open models on Modal</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/runtime.md" target="_blank" rel="noopener">runtime.md</a></td><td>Runtime setup for headless mode</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/sandboxing.md" target="_blank" rel="noopener">sandboxing.md</a></td><td>Docker (local) / Modal (remote) setup for sandboxing</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/credentials.md" target="_blank" rel="noopener">credentials.md</a></td><td>Environments &amp; secrets, walked end-to-end</td></tr>
-        <tr><td><a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/infra.md" target="_blank" rel="noopener">infra.md</a></td><td>Deploying the remote runtime to GCP and Modal</td></tr>
-      </table>
-    </div>
-  </div>
+<section id="running" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border);border-bottom:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Running the code</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">10</span></div>
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:12px 0 0;text-wrap:pretty">One Guide Per Side Quest.</h2>
+<p style="font-size:15px;line-height:1.65;color:var(--fg-2);margin:14px 0 0;white-space:nowrap">Everything lives under <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/tree/main/running_the_code" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none;font-family:var(--font-mono);font-size:14px">running_the_code/</a>. One core guide, plus one focused guide per side quest.</p>
+<div style="display:grid;margin:clamp(22px,3.4vh,34px) 0 0">
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/01_install_and_usage.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">install_and_usage.md</span><span style="font-size:14.5px;color:var(--fg-2)">Start here</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/00_troubleshooting.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">troubleshooting.md</span><span style="font-size:14.5px;color:var(--fg-2)">Every known failure, and its fix</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/02_modal_endpoints.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">modal_models.md</span><span style="font-size:14.5px;color:var(--fg-2)">Serving open models on Modal</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/03_runtime.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">runtime.md</span><span style="font-size:14.5px;color:var(--fg-2)">Runtime setup for headless mode</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/04_sandboxing.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">sandboxing.md</span><span style="font-size:14.5px;color:var(--fg-2)">Docker (local) / Modal (remote) setup for sandboxing</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/06_credentials.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">credentials.md</span><span style="font-size:14.5px;color:var(--fg-2)">Environments &amp; secrets, walked end-to-end</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+<a class="x10" href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/running_the_code/07_infra.md" target="_blank" rel="noopener" style="display:grid;grid-template-columns:260px 1fr auto;gap:clamp(16px,2vw,28px);align-items:center;padding:17px clamp(12px,1.6vw,18px);border-top:1px solid var(--border);border-bottom:1px solid var(--border);text-decoration:none"><span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg);font-weight:500">infra.md</span><span style="font-size:14.5px;color:var(--fg-2)">Deploying the remote runtime to GCP and Modal</span><i data-lucide="arrow-up-right" style="width:15px;height:15px;color:var(--primary)"></i></a>
+</div>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:clamp(20px,3vh,28px) 0 0;white-space:nowrap">Questions or setup trouble: open a <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/issues" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">GitHub issue</a>. Found a bug and know the fix? Fork, fix, run <span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg)">make ci</span> (no API key needed), and open a pull request.</p>
+</div>
 </section>
 
-<section id="sponsors">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Sponsors</h2>
-    <figure>
-      <img src="assets/github-repo-banner-dark.png" alt="Sponsored by Modal, Opik and Kitaru" style="max-width:780px">
-    </figure>
-    <p style="text-align:center;">Special thanks to <a href="https://modal.com?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener"><b>Modal</b></a>, <a href="https://www.comet.com/site/?utm_source=workshop&utm_medium=partner&utm_campaign=paul&utm_content=coding_agent_course" target="_blank" rel="noopener"><b>Opik</b></a> (by Comet), and <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&utm_medium=referral&utm_campaign=coding-agent-course&utm_content=brand" target="_blank" rel="noopener"><b>Kitaru</b></a> (by ZenML) for sponsoring this open-source course and keeping it free!</p>
-    <p style="text-align:center;">Opik and Kitaru are open source. Consider starring their repositories: <a href="https://github.com/comet-ml/opik" target="_blank" rel="noopener">Opik on GitHub</a> · <a href="https://github.com/zenml-io/kitaru" target="_blank" rel="noopener">Kitaru on GitHub</a>.</p>
-  </div>
+<section id="sponsors" style="position:relative;overflow:hidden;background:var(--gradient-warm-diag);padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px)">
+<div style="max-width:1320px;margin:0 auto;text-align:center">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:#fff;margin:0 auto;white-space:nowrap">This Course Is Free Thanks to Them.</h2>
+<div style="margin:clamp(24px,3.6vh,38px) auto 0;max-width:820px;border:1px solid rgba(0,0,0,.28);border-radius:var(--radius-lg);overflow:hidden;box-shadow:0 22px 50px rgba(0,0,0,.3)">
+<img src="assets/github-repo-banner-dark.png" alt="Sponsored by Modal, Opik and Kitaru" style="width:100%">
+</div>
+<p style="font-size:15px;line-height:1.65;color:rgba(255,255,255,.9);margin:clamp(20px,3vh,28px) auto 0;max-width:68ch">Special thanks to <a href="https://modal.com/?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:#fff;font-weight:700;text-decoration:underline">Modal</a>, <a href="https://www.comet.com/site/?utm_source=workshop&amp;utm_medium=partner&amp;utm_campaign=paul&amp;utm_content=coding_agent_course" target="_blank" rel="noopener" style="color:#fff;font-weight:700;text-decoration:underline">Opik</a> (by Comet), and <a href="https://www.zenml.io/product/kitaru?utm_source=decodingai&amp;utm_medium=referral&amp;utm_campaign=coding-agent-course&amp;utm_content=brand" target="_blank" rel="noopener" style="color:#fff;font-weight:700;text-decoration:underline">Kitaru</a> (by ZenML) for sponsoring this open-source course and keeping it free.</p>
+<p style="font-size:14px;line-height:1.65;color:rgba(255,255,255,.78);margin:10px auto 0;max-width:68ch">Opik and Kitaru are open source. Consider starring their repositories: <a href="https://github.com/comet-ml/opik" target="_blank" rel="noopener" style="color:#fff;text-decoration:underline;white-space:nowrap">Opik on GitHub</a> · <a href="https://github.com/zenml-io/kitaru" target="_blank" rel="noopener" style="color:#fff;text-decoration:underline;white-space:nowrap">Kitaru on GitHub</a>.</p>
+</div>
 </section>
 
-<section id="questions">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Questions and Troubleshooting</h2>
-    <p>Open a <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/issues" target="_blank" rel="noopener">GitHub issue</a> for course questions, setup trouble, or concept clarifications. Known gotchas are documented in the <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/tree/main/running_the_code" target="_blank" rel="noopener"><code>running_the_code/</code></a> guides.</p>
-  </div>
+<section id="faq" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--bg)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">FAQ</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span><span style="font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--fg-3);flex:none">11</span></div>
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:clamp(18px,2.6vh,26px) 0 0;white-space:nowrap">Asked and Answered.</h2>
+<div style="display:grid;gap:10px;margin:clamp(24px,3.6vh,34px) 0 0">
+<details class="x11" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:18px 22px;transition:border-color .2s">
+<summary style="cursor:pointer;font-size:16px;font-weight:700;color:var(--fg)">Do I need a paid API key?</summary>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:12px 0 0">No. The default Gemini provider has a free tier, OpenRouter routes across <span style="font-family:var(--font-mono);font-size:13.5px;color:var(--fg)">:free</span> models, and <a href="https://modal.com/?source=decodingai&amp;campaign=harnesseng" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Modal</a> gives $30 in credits — see <a href="#cost" style="color:var(--primary);text-decoration:none">Cost Structure</a>.</p>
+</details>
+<details class="x11" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:18px 22px;transition:border-color .2s">
+<summary style="cursor:pointer;font-size:16px;font-weight:700;color:var(--fg)">Why Python and not TypeScript or Go?</summary>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:12px 0 0">Accessibility: our audience knows Python. The course focuses on the design decisions, which transfer to any language.</p>
+</details>
+<details class="x11" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:18px 22px;transition:border-color .2s">
+<summary style="cursor:pointer;font-size:16px;font-weight:700;color:var(--fg)">Why build from scratch instead of extending Pi, DeepAgents, or an existing harness?</summary>
+<p style="font-size:14.5px;line-height:1.65;color:var(--fg-2);margin:12px 0 0">Because adding custom logic to an existing harness is the easy part. <i>Knowing what to add</i> requires understanding the internals. That's the fundamentals, and it's what still makes AI engineers valuable. Build a coding agent once, and you're equipped to build a custom agent for any use case.</p>
+</details>
+</div>
+</div>
 </section>
 
-<section id="faq">
-  <div class="wrap">
-    <h2><span class="hash">##</span>FAQ</h2>
-    <details>
-      <summary>Do I need a paid API key?</summary>
-      <p>No. The default Gemini provider has a free tier, OpenRouter routes across <code>:free</code> models, and <a href="https://modal.com?source=decodingai&campaign=harnesseng" target="_blank" rel="noopener">Modal</a> gives $30 in credits — see <a href="#cost">Cost Structure</a>.</p>
-    </details>
-    <details>
-      <summary>Why Python and not TypeScript or Go?</summary>
-      <p>Accessibility: our audience knows Python. The course focuses on the design decisions, which transfer to any language.</p>
-    </details>
-    <details>
-      <summary>Why build from scratch instead of extending Pi, DeepAgents, or an existing harness?</summary>
-      <p>Because adding custom logic to an existing harness is the easy part — <i>knowing what to add</i> requires understanding the internals. That's the fundamentals, and it's what still makes AI engineers valuable. Build a coding agent once and you're equipped to build a custom agent for any use case.</p>
-    </details>
-  </div>
+<section id="author" style="padding:clamp(56px,7vw,104px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto">
+<div style="display:flex;align-items:center;gap:14px"><span style="font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--primary)">Course author</span><span style="flex:1;height:1px;background:linear-gradient(90deg,var(--border-strong),transparent)"></span></div>
+<div style="display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);align-items:center;gap:clamp(24px,4vw,56px);margin:clamp(22px,3vh,32px) 0 0">
+<div style="display:flex;align-items:center;gap:18px;min-width:0">
+<a href="https://www.pauliusztin.ai/" target="_blank" rel="noopener" style="flex:none"><img src="https://github.com/iusztinpaul.png" alt="Paul Iusztin" style="width:72px;height:72px;border-radius:50%;border:1px solid var(--border-strong)"></a>
+<div style="min-width:0">
+<div style="font-size:21px;font-weight:800;letter-spacing:-.018em;color:var(--fg)">Paul Iusztin</div>
+<div style="font-size:14px;line-height:1.55;color:var(--fg-3);margin:3px 0 0">Senior AI Engineer, Educator &amp; Founder of Decoding AI</div>
+<div style="font-size:14px;line-height:1.55;color:var(--fg-2);margin:6px 0 0">Author of the best-selling <a href="https://www.amazon.com/LLM-Engineers-Handbook-engineering-production/dp/1836200072" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">LLM Engineer's Handbook</a>.</div>
+</div>
+</div>
+<div id="newsletter" style="display:flex;align-items:center;gap:18px">
+<a href="https://www.decodingai.com/" target="_blank" rel="noopener" style="flex:none"><img src="assets/decoding-ai-logo.png" alt="Decoding AI" style="width:72px;height:72px;object-fit:contain"></a>
+<div style="min-width:0">
+<div style="font-size:21px;font-weight:800;letter-spacing:-.018em;color:var(--fg)">Decoding AI Magazine</div>
+<div style="font-size:14px;line-height:1.55;color:var(--fg-2);margin:6px 0 0;max-width:58ch;text-wrap:balance">Join 40k+ engineers learning to build coding agents from scratch with the <a href="https://www.decodingai.com/" target="_blank" rel="noopener" style="color:var(--primary);text-decoration:none">Decoding AI Magazine</a>.</div>
+</div>
+</div>
+</div>
+</div>
 </section>
 
-<section id="contributing">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Contributing</h2>
-    <p>Found a bug and know the fix? Fork, fix, run <code>make ci</code> (no API key needed), and open a pull request. Future readers will thank you 🤗</p>
-  </div>
+<section style="padding:clamp(40px,5vw,64px) clamp(20px,3vw,40px);background:var(--surface-2);border-top:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto;text-align:center">
+<h2 style="font-size:clamp(26px,3.4vw,42px);font-weight:800;line-height:1.1;letter-spacing:-.028em;color:var(--fg);margin:0;text-wrap:pretty">One More Thing.</h2>
+<p style="font-size:15px;line-height:1.65;color:var(--fg-2);margin:14px auto 0;max-width:56ch">If you found this course useful, consider starring the repository so others can find it too.</p>
+<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:12px;margin:clamp(20px,3vh,28px) 0 0">
+<a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:9px;font-size:15px;font-weight:700;color:#fff;background:var(--gradient-warm);border:none;border-radius:var(--radius-pill);padding:14px 26px;text-decoration:none"><i data-lucide="star" style="width:16px;height:16px"></i>Star the repo</a>
+<a class="x10" href="https://www.decodingai.com/p/building-a-coding-agent-from-scratch-system-design" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:8px;font-size:15px;font-weight:700;color:var(--fg);background:transparent;border:1.5px solid var(--border-strong);border-radius:var(--radius-pill);padding:13px 24px;text-decoration:none;transition:background .15s">Start Lesson 1</a>
+</div>
+</div>
 </section>
 
-<section id="author">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Course Author</h2>
-    <div class="author">
-      <div class="who">
-        <a href="https://www.pauliusztin.ai/" target="_blank" rel="noopener"><img src="https://github.com/iusztinpaul.png" alt="Paul Iusztin"></a>
-        <b>Paul Iusztin</b>
-      </div>
-      <div>
-        <p>Senior AI Engineer, Educator &amp; Founder of Decoding AI. Author of the best-selling <a href="https://www.amazon.com/LLM-Engineers-Handbook-engineering-production/dp/1836200072" target="_blank" rel="noopener">LLM Engineer's Handbook</a>.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="newsletter">
-  <div class="wrap">
-    <h2><span class="hash">##</span>Learn How to Build Coding Agents From Scratch</h2>
-    <div class="newsletter">
-      <p>Join 40k+ engineers subscribed to <a href="https://www.decodingai.com/" target="_blank" rel="noopener"><b>the Decoding AI Magazine</b></a> to learn to build coding agents from scratch.</p>
-    </div>
-    <a href="https://www.decodingai.com/" target="_blank" rel="noopener"><img src="assets/decodingai.jpg" alt="Decoding AI Magazine" style="margin-top:1.4rem; border:1px solid var(--border); border-radius:10px;"></a>
-  </div>
-</section>
-
-<section id="one-more-thing">
-  <div class="wrap">
-    <h2><span class="hash">##</span>One More Thing</h2>
-    <p>If you found this course useful, consider <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course" target="_blank" rel="noopener">starring the repository</a> so others can find it too.</p>
-  </div>
-</section>
-
-<footer>
-  <div class="wrap">
-    <p>Released under <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/LICENSE" target="_blank" rel="noopener">Apache-2.0</a> — clone, fork, and build on it; keep the LICENSE and credit this repo.</p>
-  </div>
+<footer style="padding:clamp(28px,3.4vw,40px) clamp(20px,3vw,40px);background:var(--black-3);border-top:1px solid var(--border)">
+<div style="max-width:1320px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:18px">
+<div style="display:flex;align-items:center;gap:12px">
+<img src="assets/coding-agent-logo.png" alt="" style="width:26px;height:26px;opacity:.85">
+<span style="font-family:var(--font-mono);font-size:12.5px;color:#8a8c90">decode · apache-2.0 · decoding ai</span>
+</div>
+<p style="font-size:12.5px;line-height:1.6;color:#8a8c90;margin:0;white-space:nowrap">Released under <a href="https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course/blob/main/LICENSE" target="_blank" rel="noopener" style="color:var(--orange);text-decoration:none">Apache-2.0</a>. Clone, fork, and build on it; keep the LICENSE and credit this repo.</p>
+</div>
 </footer>
 
+</div>
 <script>
-  document.getElementById('copy-btn').addEventListener('click', function () {
-    var cmds = [
+(function(){
+  function icons(n){
+    n = n || 0;
+    if (window.lucide && window.lucide.createIcons) { try { window.lucide.createIcons(); } catch (e) {} return; }
+    if (n < 60) setTimeout(function(){ icons(n + 1); }, 150);
+  }
+  icons();
+  var btn = document.getElementById('om-copy-btn');
+  if (btn) btn.addEventListener('click', function(){
+    var text = [
       'git clone https://github.com/decodingai-magazine/building-a-coding-agent-from-scratch-course.git',
       'cd building-a-coding-agent-from-scratch-course',
       'make install',
       'cp .env.example .env',
       'uv run decode'
     ].join('\n');
-    navigator.clipboard.writeText(cmds).then(function () {
-      var btn = document.getElementById('copy-btn');
-      btn.textContent = 'copied!';
-      setTimeout(function () { btn.textContent = 'copy'; }, 1500);
-    });
+    var label = btn.querySelector('[data-om-copy-label]');
+    function done(){
+      if (!label) return;
+      label.textContent = 'copied!';
+      clearTimeout(btn.__t);
+      btn.__t = setTimeout(function(){ label.textContent = 'copy'; }, 1600);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(text).then(done, done);
+    else done();
   });
+})();
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
## What

Replaces the GitHub Pages landing page (`index.html`, served at building-a-coding-agent-from-scratch-course.decodingai.com) with a refreshed design, plus a round of fixes and polish.

## Changes

- **Lucide pinned + SRI** — `@latest` → `1.28.0` with an `integrity` hash and `crossorigin`, removing the supply-chain / breaking-change risk of an unpinned CDN script.
- **Broken image fixed** — the newsletter block referenced a non-existent `mascot-dark-bg.png`; repointed to the existing `assets/decoding-ai-logo.png`.
- **Hero logo** enlarged to 60px.
- **"Fresh session" frame** — the letterbox around the wide terminal screenshot is now filled with the terminal's own background (`#242835`) so it reads as intentional.
- **"See it work" grid** — caption strips collapsed to a uniform thin height and bottom-aligned across each row; each card's leftover gap is filled with that image's own background color (dark for the five dark shots, white for the light Opik shot) so the gap blends into the screenshot instead of leaving a hole.
- **`running_the_code/*.md` links** — every reference (the "Running the code" section, the lesson-outline cards, and the cost table) now points at the numbered filenames on `main`. All verified **HTTP 200**; previously they 404'd.
- **Sponsors section** — removed the "Sponsors" eyebrow and reworded the heading to "This Course Is Free Thanks to Them."

## Verification

- Rendered locally: no console errors, all 17 assets load 200, Lucide + Google Fonts load, SRI validates.
- All 8 `running_the_code/*.md` link targets checked → 200.

Docs/site only; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)